### PR TITLE
Change lifetime cap to 20

### DIFF
--- a/conf/spocs.py
+++ b/conf/spocs.py
@@ -1,6 +1,6 @@
 production = development = {
     'caps': {
-        'lifetime': 10,
+        'lifetime': 20,
         'campaign': {
             'count': 10,
             'period': 86400,


### PR DESCRIPTION


## Goal
Increase lifetime cap from 10 to 20, per request from Lillian. This will allow for wiggle room to increase the spoc cap for specific campaigns if needed.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
