### PR TITLE
Cloudformation: Adding ECS Auto Scaling

### DIFF
--- a/cloudformation/proxy-service.yaml
+++ b/cloudformation/proxy-service.yaml
@@ -27,7 +27,31 @@ Parameters:
     Type: String
     Default: 1024
 
-  EcsServiceTaskCount:
+  EcsServiceTaskDesiredCount:
+    Type: String
+    Default: 115
+
+  EcsServiceTaskMaxCount:
+    Type: String
+    Default: 250
+
+  EcsServiceTaskMinCount:
+    Type: String
+    Default: 50
+
+  EcsScaleTaskUpCount:
+    Type: String
+    Default: 9
+
+  EcsScaleTaskDownCount:
+    Type: String
+    Default: -6
+
+  EcsScaleTaskUpCooldown:
+    Type: String
+    Default: 60
+
+  EcsScaleTaskDownCooldown:
     Type: String
     Default: 300
 
@@ -42,6 +66,28 @@ Parameters:
   EcsAppAdzerkSecretName:
     Type: String
     Default: prod/adzerk
+
+  ServiceScaleEvaluationPeriods:
+    Description: "The number of periods over which data is compared to the specified threshold"
+    Type: Number
+    Default: 2
+    MinValue: 2
+
+  ServiceCpuScaleUpThreshold:
+    Type: Number
+    Description: "Average CPU value to trigger auto scaling up"
+    Default: 50
+    MinValue: 0
+    MaxValue: 100
+    ConstraintDescription: Value must be between 0 and 100
+
+  ServiceCpuScaleDownThreshold:
+    Type: Number
+    Description: "Average CPU value to trigger auto scaling down"
+    Default: 40
+    MinValue: 0
+    MaxValue: 100
+    ConstraintDescription: Value must be between 0 and 100
 
   SSLCertificateArn:
     Type: String
@@ -191,7 +237,7 @@ Resources:
     Properties:
       Cluster: !Ref "EcsCluster"
       LaunchType: FARGATE
-      DesiredCount: !Ref "EcsServiceTaskCount"
+      DesiredCount: !Ref "EcsServiceTaskDesiredCount"
       LoadBalancers:
         - ContainerPort: 80
           ContainerName: nginx
@@ -271,6 +317,7 @@ Resources:
           Value: !Sub "${AWS::StackName}-ecs"
       VpcId: { 'Fn::ImportValue': !Sub "${VPCStackName}-VpcId" }
 
+
   EcsSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -279,3 +326,112 @@ Resources:
       FromPort: 80
       ToPort: 80
       SourceSecurityGroupId: !Ref "AlbSecurityGroup"
+
+  EcsAutoScalingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-AutoScalingRole"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: application-autoscaling.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: !Sub "${AWS::StackName}-AutoScalingPolicy"
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - application-autoscaling:*
+                  - cloudwatch:DescribeAlarms
+                  - cloudwatch:PutMetricAlarm
+                  - ecs:DescribeServices
+                  - ecs:UpdateService
+                Resource:
+                  - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/${AWS::StackName}-*"
+                  - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/${AWS::StackName}:*"
+                  - !Sub "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${AWS::StackName}-*"
+
+  ServiceScalingTarget:
+    Type: "AWS::ApplicationAutoScaling::ScalableTarget"
+    Properties:
+      MinCapacity: !Ref "EcsServiceTaskMinCount"
+      MaxCapacity: !Ref "EcsServiceTaskMaxCount"
+      ResourceId: !Sub
+        - "service/${EcsClusterName}/${EcsServiceName}"
+        - EcsClusterName: !Ref "EcsCluster"
+          EcsServiceName: !GetAtt EcsService.Name
+      RoleARN: !GetAtt EcsAutoScalingRole.Arn
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+
+  ServiceScaleUpPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ScaleOutPolicy
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ServiceScalingTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: !Ref EcsScaleTaskUpCooldown
+        MetricAggregationType: Average
+        StepAdjustments:
+          - ScalingAdjustment: !Ref EcsScaleTaskUpCount
+            MetricIntervalLowerBound: 0
+
+  ServiceScaleDownPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ScaleInPolicy
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ServiceScalingTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: !Ref EcsScaleTaskDownCooldown
+        MetricAggregationType: Average
+        StepAdjustments:
+          - ScalingAdjustment: !Ref EcsScaleTaskDownCount
+            MetricIntervalUpperBound: 0
+
+  ServiceCPUScaleUpAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      EvaluationPeriods: !Ref ServiceScaleEvaluationPeriods
+      Statistic: Average
+      TreatMissingData: breaching
+      Threshold: !Ref ServiceCpuScaleUpThreshold
+      AlarmDescription: Alarm to add capacity if CPU is high
+      Period: 60
+      AlarmActions:
+        - !Ref ServiceScaleUpPolicy
+      Namespace: AWS/ECS
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref "EcsCluster"
+        - Name: ServiceName
+          Value: !GetAtt EcsService.Name
+      ComparisonOperator: GreaterThanThreshold
+      MetricName: CPUUtilization
+
+  ServiceCPUScaleDownAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      EvaluationPeriods: !Ref ServiceScaleEvaluationPeriods
+      Statistic: Average
+      TreatMissingData: breaching
+      Threshold: !Ref ServiceCpuScaleDownThreshold
+      AlarmDescription: Alarm to reduce capacity if container CPU is low
+      Period: 300
+      AlarmActions:
+        - !Ref ServiceScaleDownPolicy
+      Namespace: AWS/ECS
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref "EcsCluster"
+        - Name: ServiceName
+          Value: !GetAtt EcsService.Name
+      ComparisonOperator: LessThanThreshold
+      MetricName: CPUUtilization
+

--- a/tests/load/serverless.yml
+++ b/tests/load/serverless.yml
@@ -17,7 +17,7 @@ service: serverless-artillery-dev
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   iamRoleStatements:
     # This policy allows the function to invoke itself which is important if the script is larger than a single
     # function can produce


### PR DESCRIPTION
## Goal

Add auto scaling for ecs tasks based on average cpu utilization. 

## Implementation Decisions

Enable ECS tasks to scale based on average cpu utilization above 51% and scale down on average cpu utilization bellow 40%.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
