### PR TITLE
Make sponsor field optional

### DIFF
--- a/adzerk/transform.py
+++ b/adzerk/transform.py
@@ -19,7 +19,6 @@ def to_spoc(decision):
         'url':               custom_data['ctUrl'],
         'domain':            custom_data['ctDomain'],
         'excerpt':           custom_data['ctExcerpt'],
-        'sponsor':           custom_data['ctSponsor'],
         'context':           __get_context(custom_data['ctSponsor']),
         'raw_image_src':     custom_data['ctFullimagepath'],
         'image_src':         __get_cdn_image(custom_data['ctFullimagepath']),
@@ -37,6 +36,7 @@ def to_spoc(decision):
     optional_fields = {
         'ctCta':             'cta',
         'ctCollectionTitle': 'collection_title',
+        'ctSponsor':         'sponsor',
     }
     for adzerk_key, spoc_key in optional_fields.items():
         if adzerk_key in custom_data and custom_data[adzerk_key]:

--- a/adzerk/transform.py
+++ b/adzerk/transform.py
@@ -113,7 +113,7 @@ def __get_cdn_image(raw_image_url):
 
 
 def __get_context(sponsor):
-    return 'Sponsored by {0}'.format(sponsor) if sponsor else None
+    return 'Sponsored by {0}'.format(sponsor) if sponsor else ''
 
 
 def __get_domain_affinities(name):

--- a/adzerk/transform.py
+++ b/adzerk/transform.py
@@ -24,7 +24,7 @@ def to_spoc(decision):
         'url':                    custom_data['ctUrl'],
         'domain':                 custom_data['ctDomain'],
         'excerpt':                custom_data['ctExcerpt'],
-        'context':                __get_context(custom_data['ctSponsor']),
+        'context':                __get_context(custom_data.get('ctSponsor')),
         'raw_image_src':          custom_data['ctFullimagepath'],
         'image_src':              __get_cdn_image(custom_data['ctFullimagepath']),
         'shim':      {
@@ -113,7 +113,7 @@ def __get_cdn_image(raw_image_url):
 
 
 def __get_context(sponsor):
-    return 'Sponsored by {0}'.format(sponsor)
+    return 'Sponsored by {0}'.format(sponsor) if sponsor else None
 
 
 def __get_domain_affinities(name):

--- a/tests/fixtures/mock_decision.py
+++ b/tests/fixtures/mock_decision.py
@@ -161,3 +161,7 @@ mock_collection_response['contents'][0]['data']['ctCollectionTitle'] = "Best of 
 mock_decision_5_topics = deepcopy(mock_decision_2)
 mock_decision_5_topics['adId'] = 5
 mock_decision_5_topics['contents'][0]['body'] = "{\"topic_arts_and_entertainment\":\"\",\"topic_autos_and_vehicles\":\"true\",\"topic_beauty_and_fitness\":\"true\"}"
+
+mock_decision_6_no_sponsor = deepcopy(mock_decision_2)
+mock_decision_6_no_sponsor['adId'] = 6
+del mock_decision_6_no_sponsor['contents'][0]['data']['ctSponsor']

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -57,3 +57,8 @@ mock_collection = {
 mock_spoc_5_topics = deepcopy(mock_spoc_2)
 mock_spoc_5_topics["id"] = 5
 mock_spoc_5_topics["personalization_models"] = ["nb_model_autos_and_vehicles", "nb_model_beauty_and_fitness"]
+
+mock_spoc_6_no_sponsor = deepcopy(mock_spoc_2)
+mock_spoc_6_no_sponsor["id"] = 6
+del mock_spoc_6_no_sponsor["sponsor"]
+mock_spoc_6_no_sponsor["context"] = None

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -61,4 +61,4 @@ mock_spoc_5_topics["personalization_models"] = ["nb_model_autos_and_vehicles", "
 mock_spoc_6_no_sponsor = deepcopy(mock_spoc_2)
 mock_spoc_6_no_sponsor["id"] = 6
 del mock_spoc_6_no_sponsor["sponsor"]
-mock_spoc_6_no_sponsor["context"] = None
+mock_spoc_6_no_sponsor["context"] = ""

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -3,8 +3,10 @@ from unittest.mock import patch
 
 from adzerk.transform import to_spoc, tracking_url_to_shim, is_collection, to_collection, get_personalization_models
 from tests.fixtures.mock_spoc import \
-    mock_spoc_2, mock_spoc_3_cta, mock_collection_spoc_2, mock_collection_spoc_3, mock_collection, mock_spoc_5_topics
-from tests.fixtures.mock_decision import mock_decision_2, mock_decision_3_cta, mock_decision_5_topics
+    mock_spoc_2, mock_spoc_3_cta, mock_collection_spoc_2, mock_collection_spoc_3, mock_collection, mock_spoc_5_topics,\
+    mock_spoc_6_no_sponsor
+from tests.fixtures.mock_decision import mock_decision_2, mock_decision_3_cta, mock_decision_5_topics,\
+    mock_decision_6_no_sponsor
 
 
 class TestAdZerkTransform(TestCase):
@@ -19,6 +21,10 @@ class TestAdZerkTransform(TestCase):
     @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
     def test_to_spoc_topics(self):
         self.assertEqual(mock_spoc_5_topics, to_spoc(mock_decision_5_topics))
+
+    @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
+    def test_to_spoc_no_sponsor(self):
+        self.assertEqual(mock_spoc_6_no_sponsor, to_spoc(mock_decision_6_no_sponsor))
 
     def test_tracking_url_to_shim(self):
         self.assertEqual('0,eyJ,Zz', tracking_url_to_shim('https://e-10250.adzerk.net/r?e=eyJ&s=Zz'))


### PR DESCRIPTION
## Goal
Mozilla will run a campaign in the collection component that shouldn't have a "Sponsored by" subtitle. To remove this, we'll leave the sponsor field empty and remove it in the proxy server.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?