### PR TITLE
Added topics to response

### DIFF
--- a/adzerk/transform.py
+++ b/adzerk/transform.py
@@ -17,27 +17,27 @@ def to_spoc(decision):
     events_map = {e["id"]: tracking_url_to_shim(e["url"]) for e in decision["events"]}
 
     spoc = {
-        'id':                decision['adId'],
-        'flight_id':         decision['flightId'],
-        'campaign_id':       decision['campaignId'],
-        'title':             custom_data['ctTitle'],
-        'url':               custom_data['ctUrl'],
-        'domain':            custom_data['ctDomain'],
-        'excerpt':           custom_data['ctExcerpt'],
-        'sponsor':           custom_data['ctSponsor'],
-        'context':           __get_context(custom_data['ctSponsor']),
-        'raw_image_src':     custom_data['ctFullimagepath'],
-        'image_src':         __get_cdn_image(custom_data['ctFullimagepath']),
-        'shim': {
-            'click':         tracking_url_to_shim(decision['clickUrl']),
-            'impression':    tracking_url_to_shim(decision['impressionUrl']),
-            'delete':        events_map[17],
-            'save':          events_map[20],
+        'id':                     decision['adId'],
+        'flight_id':              decision['flightId'],
+        'campaign_id':            decision['campaignId'],
+        'title':                  custom_data['ctTitle'],
+        'url':                    custom_data['ctUrl'],
+        'domain':                 custom_data['ctDomain'],
+        'excerpt':                custom_data['ctExcerpt'],
+        'sponsor':                custom_data['ctSponsor'],
+        'context':                __get_context(custom_data['ctSponsor']),
+        'raw_image_src':          custom_data['ctFullimagepath'],
+        'image_src':              __get_cdn_image(custom_data['ctFullimagepath']),
+        'shim':      {
+            'click':              tracking_url_to_shim(decision['clickUrl']),
+            'impression':         tracking_url_to_shim(decision['impressionUrl']),
+            'delete':             events_map[17],
+            'save':               events_map[20],
         },
-        'parameter_set':     'default',
-        'caps':              conf.spocs['caps'],
-        'domain_affinities': __get_domain_affinities(custom_data.get('ctDomain_affinities')),
-        'topics':            get_topics(body),
+        'parameter_set':          'default',
+        'caps':                   conf.spocs['caps'],
+        'domain_affinities':      __get_domain_affinities(custom_data.get('ctDomain_affinities')),
+        'personalization_models': get_personalization_models(body),
     }
 
     optional_fields = {
@@ -98,10 +98,11 @@ def to_collection(spocs):
     return collection
 
 
-def get_topics(body):
+def get_personalization_models(body):
     if body is None:
         return {}
     else:
+        # Topics in AdZerk prefixed with topic_ correspond with models in Firefox prefixed with nb_model_.
         p = re.compile('^topic_')
         return [p.sub('nb_model_', t) for t, v in body.items() if p.match(t) and v in ('true', True)]
 

--- a/tests/fixtures/mock_decision.py
+++ b/tests/fixtures/mock_decision.py
@@ -10,7 +10,6 @@ mock_response = {
   "contents": [
     {
       "type": "html",
-      "body": "Example",
       "template": "image",
       "data": {
         "imageUrl": "http://static.adzerk.net/cat.jpg",
@@ -67,7 +66,6 @@ mock_response_900 = {
   "contents": [
     {
       "type": "html",
-      "body": "Example",
       "template": "image",
       "data": {
         "imageUrl": "http://static.adzerk.net/cat.jpg",

--- a/tests/fixtures/mock_decision.py
+++ b/tests/fixtures/mock_decision.py
@@ -159,3 +159,7 @@ mock_decision_3_cta['contents'][0]['data']['ctCta'] = "Learn more"
 mock_collection_response = deepcopy(mock_response_900)
 mock_collection_response['adId'] = 4
 mock_collection_response['contents'][0]['data']['ctCollectionTitle'] = "Best of the Web"
+
+mock_decision_5_topics = deepcopy(mock_decision_2)
+mock_decision_5_topics['adId'] = 5
+mock_decision_5_topics['contents'][0]['body'] = "{\"topic_arts_and_entertainment\":\"\",\"topic_autos_and_vehicles\":\"true\",\"topic_beauty_and_fitness\":\"true\"}"

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -33,6 +33,7 @@ mock_spoc_2 = {
     "domain_affinities": {
         "example.com": 1
     },
+    "topics": {},
     "min_score": 0.1,
     "item_score": 0.11,
 }
@@ -52,3 +53,7 @@ mock_collection = {
     "flight_id": 8525375,
     "items": [deepcopy(mock_spoc_2), deepcopy(mock_spoc_3_cta)]
 }
+
+mock_spoc_5_topics = deepcopy(mock_spoc_2)
+mock_spoc_5_topics["id"] = 5
+mock_spoc_5_topics["topics"] = ["nb_model_autos_and_vehicles", "nb_model_beauty_and_fitness"]

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -33,7 +33,7 @@ mock_spoc_2 = {
     "domain_affinities": {
         "example.com": 1
     },
-    "topics": {},
+    "personalization_models": {},
     "min_score": 0.1,
     "item_score": 0.11,
 }
@@ -56,4 +56,4 @@ mock_collection = {
 
 mock_spoc_5_topics = deepcopy(mock_spoc_2)
 mock_spoc_5_topics["id"] = 5
-mock_spoc_5_topics["topics"] = ["nb_model_autos_and_vehicles", "nb_model_beauty_and_fitness"]
+mock_spoc_5_topics["personalization_models"] = ["nb_model_autos_and_vehicles", "nb_model_beauty_and_fitness"]

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from adzerk.transform import to_spoc, tracking_url_to_shim, is_collection, to_collection, get_topics
+from adzerk.transform import to_spoc, tracking_url_to_shim, is_collection, to_collection, get_personalization_models
 from tests.fixtures.mock_spoc import \
     mock_spoc_2, mock_spoc_3_cta, mock_collection_spoc_2, mock_collection_spoc_3, mock_collection, mock_spoc_5_topics
 from tests.fixtures.mock_decision import mock_decision_2, mock_decision_3_cta, mock_decision_5_topics
@@ -40,17 +40,17 @@ class TestAdZerkTransform(TestCase):
     def test_get_topics(self):
         self.assertEqual(
             ['nb_model_business', 'nb_model_technology'],
-            get_topics({'topic_business': 'true', 'topic_technology': True}))
+            get_personalization_models({'topic_business': 'true', 'topic_technology': True}))
 
         self.assertEqual(
             [],
-            get_topics({'topic_business': '', 'topic_technology': ''}))
+            get_personalization_models({'topic_business': '', 'topic_technology': ''}))
 
         self.assertEqual(
             ['nb_model_business'],
-            get_topics({'topic_business': 'true', 'topic_technology': 'false'}))
+            get_personalization_models({'topic_business': 'true', 'topic_technology': 'false'}))
 
         self.assertEqual(
             ['nb_model_arts_and_entertainment'],
-            get_topics({'other_property_business': 'true', 'topic_arts_and_entertainment': 'true'}))
+            get_personalization_models({'other_property_business': 'true', 'topic_arts_and_entertainment': 'true'}))
 

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -1,9 +1,10 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from adzerk.transform import to_spoc, tracking_url_to_shim, is_collection, to_collection
-from tests.fixtures.mock_spoc import mock_spoc_2, mock_spoc_3_cta, mock_collection_spoc_2, mock_collection_spoc_3, mock_collection
-from tests.fixtures.mock_decision import mock_decision_2, mock_decision_3_cta
+from adzerk.transform import to_spoc, tracking_url_to_shim, is_collection, to_collection, get_topics
+from tests.fixtures.mock_spoc import \
+    mock_spoc_2, mock_spoc_3_cta, mock_collection_spoc_2, mock_collection_spoc_3, mock_collection, mock_spoc_5_topics
+from tests.fixtures.mock_decision import mock_decision_2, mock_decision_3_cta, mock_decision_5_topics
 
 
 class TestAdZerkTransform(TestCase):
@@ -14,6 +15,10 @@ class TestAdZerkTransform(TestCase):
     @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
     def test_to_spoc_cta(self):
         self.assertEqual(mock_spoc_3_cta, to_spoc(mock_decision_3_cta))
+
+    @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
+    def test_to_spoc_topics(self):
+        self.assertEqual(mock_spoc_5_topics, to_spoc(mock_decision_5_topics))
 
     def test_tracking_url_to_shim(self):
         self.assertEqual('0,eyJ,Zz', tracking_url_to_shim('https://e-10250.adzerk.net/r?e=eyJ&s=Zz'))
@@ -31,3 +36,21 @@ class TestAdZerkTransform(TestCase):
 
     def test_to_collection(self):
         self.assertEqual(mock_collection, to_collection([mock_collection_spoc_2, mock_collection_spoc_3]))
+
+    def test_get_topics(self):
+        self.assertEqual(
+            ['nb_model_business', 'nb_model_technology'],
+            get_topics({'topic_business': 'true', 'topic_technology': True}))
+
+        self.assertEqual(
+            [],
+            get_topics({'topic_business': '', 'topic_technology': ''}))
+
+        self.assertEqual(
+            ['nb_model_business'],
+            get_topics({'topic_business': 'true', 'topic_technology': 'false'}))
+
+        self.assertEqual(
+            ['nb_model_arts_and_entertainment'],
+            get_topics({'other_property_business': 'true', 'topic_arts_and_entertainment': 'true'}))
+


### PR DESCRIPTION
## Goal
Pass topics from AdZerk to the client. Sponsored content can have one or multiple topics that allow for client-side personalization.

## Implementation Decisions
On the AdZerk side this is implemented as a custom property. AdZerk supports passing these in the 'data' or 'body' object. I opted for the 'body' approach to prevent existing fields (title, url, etc.) from getting mingled with 25 topic fields. This way the response is still readable for humans. The downside is that the 'body' object is json-encoded encoded twice.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
