### PR TITLE
Set a default zone

### DIFF
--- a/adzerk/api.py
+++ b/adzerk/api.py
@@ -66,8 +66,10 @@ class Api:
             default_placement = body['placements'].pop(0)   # remove default
             for place in self.placements:
                 copy_place = deepcopy(default_placement)
-                copy_place['adTypes'] = place['ad_types'] if 'ad_types' in place else None
-                copy_place['zoneIds'] = place['zone_ids'] if 'zone_ids' in place else None
+                if 'ad_types' in place:
+                    copy_place['adTypes'] = place['ad_types']
+                if 'zone_ids' in place:
+                    copy_place['zoneIds'] = place['zone_ids']
                 copy_place['divName'] = place['name']
                 body['placements'].append(copy_place)
 

--- a/conf/adzerk.py
+++ b/conf/adzerk.py
@@ -25,6 +25,7 @@ default = {
                 "networkId": network_id,
                 "siteId": 1070098,
                 "adTypes": [2401, 3617],
+                "zoneIds": [217995],
                 "count": 20,
                 "eventIds": [17, 20],
             }]

--- a/tests/fixtures/mock_placements.py
+++ b/tests/fixtures/mock_placements.py
@@ -1,3 +1,13 @@
+mock_spocs_placement = [
+    {
+        "name": "spocs",
+        "ad_types": [
+            2401,
+            3617
+        ]
+    }
+]
+
 mock_placements = [
     {
         "name": "top-sites",
@@ -9,7 +19,6 @@ mock_placements = [
         "ad_types": [99, 400],
         "zone_ids": [5000],
     }
-
 ]
 
 mock_collection_placements = [
@@ -29,6 +38,9 @@ mock_collection_placements = [
         "ad_types": [
             2401,
             3617
+        ],
+        "zone_ids": [
+            217995
         ],
         "count": 20
     }

--- a/tests/unit/test_adzerk_api.py
+++ b/tests/unit/test_adzerk_api.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import responses
 
 from adzerk.api import Api
-from tests.fixtures.mock_placements import mock_placements
+from tests.fixtures.mock_placements import mock_placements, mock_spocs_placement
 
 
 class TestAdZerkApi(TestCase):
@@ -64,6 +64,14 @@ class TestAdZerkApi(TestCase):
             self.assertEqual(10250, p['networkId'])
             self.assertEqual(1070098, p['siteId'])
             self.assertEqual(20, p['count'])
+            self.assertEqual([5000], p['zoneIds'])
+
+    def test_default_zone(self):
+        api = Api(pocket_id="{123}", placements=mock_spocs_placement)
+        body = api.get_decision_body()
+        self.assertTrue(1, len(body['placements']))
+        for p in body['placements']:
+            self.assertEqual([217995], p['zoneIds'])
 
     @patch.dict('conf.adzerk', {"api_key": "DUMMY_123"})
     @responses.activate


### PR DESCRIPTION
## Goal
The only targeting parameter that distinguishes Story Collections from 3x7 is the Zone. Older versions of Firefox do not specify a Zone, but going forward, all requests to AdZerk should have one. This change will set 217995 (which maps to the 3x7 zone) as the default.

## Implementation Decisions


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
