### PR TITLE
Add context to story collection

### DIFF
--- a/adzerk/transform.py
+++ b/adzerk/transform.py
@@ -89,6 +89,7 @@ def to_collection(spocs):
         'title':     spocs[0]['collection_title'],
         'flight_id': spocs[0]['flight_id'],
         'sponsor':   spocs[0]['sponsor'],
+        'context':   __get_context(spocs[0]['sponsor']),
     }
 
     for spoc in spocs:

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -50,6 +50,7 @@ mock_collection_spoc_3["collection_title"] = "Best of the Web"
 mock_collection = {
     "title": "Best of the Web",
     "sponsor": "WallMarket",
+    "context": "Sponsored by WallMarket",
     "flight_id": 8525375,
     "items": [deepcopy(mock_spoc_2), deepcopy(mock_spoc_3_cta)]
 }


### PR DESCRIPTION
## Goal
The localization of "Sponsored by" is not yet happening in Firefox 75, so we need to return a context field for collections.

## Implementation Decisions
- I filed [a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1618064) to discuss moving the localization to Firefox for 76.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
