### PR TITLE
Added country and region parameters

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -37,10 +37,15 @@ class Client:
 
         try:
             geo = self.geolocation.get_city(self.ip)
-            targeting['country'] = self.country if self.country else self.geolocation.get_country(geo)
-            targeting['region'] = self.region if self.region else self.geolocation.get_region(geo)
+            targeting['country'] = self.geolocation.get_country(geo)
+            targeting['region'] = self.geolocation.get_region(geo)
         except Exception as e:
             logging.warning("Could not target based on geolocation. {0}".format(str(e)))
+
+        if self.country:
+            targeting['country'] = self.country
+        if self.region:
+            targeting['region'] = self.region
 
         if self.pocket_id:
             targeting['pocket_id'] = self.pocket_id

--- a/app/client.py
+++ b/app/client.py
@@ -7,11 +7,24 @@ import logging
 class Client:
 
     def __init__(self, version, consumer_key, pocket_id, ip, geolocation_provider,
-                 site=None, placements=None):
+                 site=None, placements=None, country=None, region=None):
+        """
+        :param version: API version to provide backwards-compatibility to older clients
+        :param consumer_key: Identifies the consumer (e.g. Firefox)
+        :param pocket_id: Anonymous Pocket user id
+        :param ip: Client IP-address
+        :param geolocation_provider: GeoIP2 database that converts an IP to a geolocation.
+        :param site: Override the site. Leave None to use the default Firefox Production site.
+        :param placements: Override the default placements. Leave None to get spocs.
+        :param country: Set the country for debugging purposes. Leave None for IP-based geolocation.
+        :param region: Set the region for debugging purposes. Leave None for IP-based geolocation.
+        """
         self.version = int(version)
         self.consumer_key = consumer_key
         self.pocket_id = pocket_id
         self.ip = ip
+        self.country = country
+        self.region = region
         if not geolocation_provider:
             logging.error('Need geolocation object')
         else:
@@ -24,8 +37,8 @@ class Client:
 
         try:
             geo = self.geolocation.get_city(self.ip)
-            targeting['country'] = self.geolocation.get_country(geo)
-            targeting['region'] = self.geolocation.get_region(geo)
+            targeting['country'] = self.country if self.country else self.geolocation.get_country(geo)
+            targeting['region'] = self.region if self.region else self.geolocation.get_region(geo)
         except Exception as e:
             logging.warning("Could not target based on geolocation. {0}".format(str(e)))
 

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ def create_app():
     @app.route('/spocs', methods=['POST'])
     def get_spocs():
         required_params = set(['version', 'consumer_key', 'pocket_id'])
-        optional_params = set(['site', 'placements'])
+        optional_params = set(['site', 'placements', 'country', 'region'])
         req_params = __get_request_params()
         return call(req_params, required_params, optional_params=optional_params)
 
@@ -110,8 +110,8 @@ def create_app():
         for k, v in request.json.items():
             req_params.update({k: v})
         for k, v in request.args.items():
-            if k == 'site':
-                req_params.update({'site': v})
+            if k in ('site', 'country', 'region'):
+                req_params.update({k: v})
         if 'site' not in req_params:
             req_params.update({'site': None})
         if 'placements' not in req_params:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -58,6 +58,16 @@ class TestApp(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
     @patch('provider.geo_provider.GeolocationProvider.__init__', return_value=None)
+    @patch('adzerk.api.Api.get_decisions', return_value=mock_response_map)
+    def test_app_spocs_production_valid(self, mock_geo, mock_adzerk):
+        country_region = {
+            'country': 'CA',
+            'region': 'ON',
+        }
+        resp = self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(update=country_region))
+        self.assertEqual(resp.status_code, 200)
+
+    @patch('provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('adzerk.api.Api.get_decisions', return_value=mock_collection_placement_map)
     def test_app_spocs_collection_v1(self, mock_geo, mock_adzerk):
         """


### PR DESCRIPTION
## Goal
We've started targeting spocs by geolocation in AdZerk and need to give developers a way to override which region they are in. This PR adds a `country` and a `region` query parameter to override those keywords.

## Implementation Decisions

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
