### PR TITLE
Change geolocation keyword format to match ISO 3166

### DIFF
--- a/adzerk/api.py
+++ b/adzerk/api.py
@@ -48,9 +48,9 @@ class Api:
         if self.pocket_id is not None:
             body['user'] = {'key': self.pocket_id}
         keywords = []
-        if self.country is not None:
+        if self.country:
             keywords.append(self.country)
-            if self.region is not None:
+            if self.region:
                 keywords.append(self.country + '-' + self.region)
         if keywords:
             body['keywords'] = keywords

--- a/adzerk/api.py
+++ b/adzerk/api.py
@@ -49,9 +49,9 @@ class Api:
             body['user'] = {'key': self.pocket_id}
         keywords = []
         if self.country is not None:
-            keywords.append('country-' + self.country)
-        if self.region is not None:
-            keywords.append('region-' + self.region)
+            keywords.append(self.country)
+            if self.region is not None:
+                keywords.append(self.country + '-' + self.region)
         if keywords:
             body['keywords'] = keywords
 

--- a/tests/unit/test_adzerk_api.py
+++ b/tests/unit/test_adzerk_api.py
@@ -51,6 +51,11 @@ class TestAdZerkApi(TestCase):
         self.assertTrue('US' in body['keywords'])
         self.assertTrue('US-CA' in body['keywords'])
 
+    def test_missing_region(self):
+        api = Api(pocket_id="{123}", country='US', region='')
+        body = api.get_decision_body()
+        self.assertEqual(['US'], body['keywords'])
+
     def test_keywords_empty(self):
         api = Api(pocket_id="{123}")
         body = api.get_decision_body()
@@ -76,11 +81,11 @@ class TestAdZerkApi(TestCase):
     @patch.dict('conf.adzerk', {"api_key": "DUMMY_123"})
     @responses.activate
     def test_site_is_not_stored_in_conf(self):
-        api = Api(pocket_id="{123}", country='USA', region='CA', site=1084367)
+        api = Api(pocket_id="{123}", country='US', region='CA', site=1084367)
         body = api.get_decision_body()
         self.assertEqual(1084367, body['placements'][0]['siteId'])
 
-        api = Api(pocket_id="{123}", country='USA', region='CA')
+        api = Api(pocket_id="{123}", country='US', region='CA')
         body = api.get_decision_body()
         self.assertEqual(1070098, body['placements'][0]['siteId'])
 

--- a/tests/unit/test_adzerk_api.py
+++ b/tests/unit/test_adzerk_api.py
@@ -46,10 +46,10 @@ class TestAdZerkApi(TestCase):
         self.assertEqual('DUMMY_123', request.headers['X-Adzerk-ApiKey'])
 
     def test_keywords(self):
-        api = Api(pocket_id="{123}", country='USA', region='CA')
+        api = Api(pocket_id="{123}", country='US', region='CA')
         body = api.get_decision_body()
-        self.assertTrue('country-USA' in body['keywords'])
-        self.assertTrue('region-CA' in body['keywords'])
+        self.assertTrue('US' in body['keywords'])
+        self.assertTrue('US-CA' in body['keywords'])
 
     def test_keywords_empty(self):
         api = Api(pocket_id="{123}")


### PR DESCRIPTION
## Goal
Change the keyword format for country and region to match ISO 3166-2. This has two advantages:
1. It's standardized, so ad-ops can easily look up the right code in the [ISO Online Browsing Platform](https://www.iso.org/obp/ui/#search/code/).
2. By adding the country code to the region keyword, targeting regions is simplified. `country-US, region-CA` is turned into `US-CA`.

## Todos:
- [X] Tested locally with IP from several countries to verify GeoIP2 matches ISO 3166.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
