### PR TITLE
Return empty sponsored_by_override if 'blank' in AdZerk

### DIFF
--- a/adzerk/transform.py
+++ b/adzerk/transform.py
@@ -50,6 +50,9 @@ def to_spoc(decision):
         if adzerk_key in custom_data and custom_data[adzerk_key]:
             spoc[spoc_key] = custom_data[adzerk_key]
 
+    if 'sponsored_by_override' in spoc:
+        spoc['sponsored_by_override'] = __clean_sponsored_by_override(spoc['sponsored_by_override'])
+
     try:
         spoc['min_score']  = float(custom_data['ctMin_score'])
         spoc['item_score'] = float(custom_data['ctItem_score'])
@@ -130,3 +133,11 @@ def __get_domain_affinities(name):
         return {}
     else:
         return conf.domain_affinities.get(str(name).lower(), dict())
+
+
+def __clean_sponsored_by_override(sponsored_by_override):
+    """
+    Return an empty string for 'sponsored_by_override' if the value in AdZerk is set to "blank" or "empty".
+    @type sponsored_by_override: str
+    """
+    return re.sub(r'^(blank|empty)$', '', sponsored_by_override.strip(), flags=re.IGNORECASE)

--- a/tests/fixtures/mock_decision.py
+++ b/tests/fixtures/mock_decision.py
@@ -170,3 +170,11 @@ del mock_decision_6_no_sponsor['contents'][0]['data']['ctSponsor']
 mock_decision_7_is_video = deepcopy(mock_decision_2)
 mock_decision_7_is_video['adId'] = 7
 mock_decision_7_is_video['contents'][0]['data']['ctIsVideo'] = " Yes  "
+
+mock_decision_8_blank_sponsored_by_override = deepcopy(mock_decision_2)
+mock_decision_8_blank_sponsored_by_override['adId'] = 8
+mock_decision_8_blank_sponsored_by_override['contents'][0]['data']['ctSponsoredByOverride'] = "BLANK "
+
+mock_decision_9_blank_sponsored_by_override = deepcopy(mock_decision_2)
+mock_decision_9_blank_sponsored_by_override['adId'] = 9
+mock_decision_9_blank_sponsored_by_override['contents'][0]['data']['ctSponsoredByOverride'] = "Brought by blank"

--- a/tests/fixtures/mock_decision.py
+++ b/tests/fixtures/mock_decision.py
@@ -175,6 +175,6 @@ mock_decision_8_blank_sponsored_by_override = deepcopy(mock_decision_2)
 mock_decision_8_blank_sponsored_by_override['adId'] = 8
 mock_decision_8_blank_sponsored_by_override['contents'][0]['data']['ctSponsoredByOverride'] = "BLANK "
 
-mock_decision_9_blank_sponsored_by_override = deepcopy(mock_decision_2)
-mock_decision_9_blank_sponsored_by_override['adId'] = 9
-mock_decision_9_blank_sponsored_by_override['contents'][0]['data']['ctSponsoredByOverride'] = "Brought by blank"
+mock_decision_9_sponsored_by_override = deepcopy(mock_decision_2)
+mock_decision_9_sponsored_by_override['adId'] = 9
+mock_decision_9_sponsored_by_override['contents'][0]['data']['ctSponsoredByOverride'] = "Brought by blank"

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -67,3 +67,7 @@ mock_spoc_6_no_sponsor["context"] = ""
 mock_spoc_7_is_video = deepcopy(mock_spoc_2)
 mock_spoc_7_is_video["id"] = 7
 mock_spoc_7_is_video["is_video"] = True
+
+mock_spoc_8_blank_sponsored_by_override = deepcopy(mock_spoc_2)
+mock_spoc_8_blank_sponsored_by_override["id"] = 8
+mock_spoc_8_blank_sponsored_by_override["sponsored_by_override"] = ""

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -71,3 +71,7 @@ mock_spoc_7_is_video["is_video"] = True
 mock_spoc_8_blank_sponsored_by_override = deepcopy(mock_spoc_2)
 mock_spoc_8_blank_sponsored_by_override["id"] = 8
 mock_spoc_8_blank_sponsored_by_override["sponsored_by_override"] = ""
+
+mock_spoc_9_sponsored_by_override = deepcopy(mock_spoc_2)
+mock_spoc_9_sponsored_by_override["id"] = 9
+mock_spoc_9_sponsored_by_override["sponsored_by_override"] = "Brought by blank"

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -29,8 +29,9 @@ class TestAdZerkTransform(TestCase):
         self.assertEqual(mock_spoc_7_is_video, to_spoc(mock_decision_7_is_video))
 
     @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
-    def test_to_spoc_is_video(self):
+    def test_to_spoc_sponsored_by_override(self):
         self.assertEqual(mock_spoc_8_blank_sponsored_by_override, to_spoc(mock_decision_8_blank_sponsored_by_override))
+        self.assertEqual(mock_spoc_9_sponsored_by_override, to_spoc(mock_decision_9_sponsored_by_override))
 
     def test_tracking_url_to_shim(self):
         self.assertEqual('0,eyJ,Zz', tracking_url_to_shim('https://e-10250.adzerk.net/r?e=eyJ&s=Zz'))

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -3,11 +3,8 @@ from unittest.mock import patch
 
 from adzerk.transform import \
     to_spoc, tracking_url_to_shim, is_collection, to_collection, get_personalization_models
-from tests.fixtures.mock_spoc import \
-    mock_spoc_2, mock_spoc_3_cta, mock_collection_spoc_2, mock_collection_spoc_3, mock_collection, mock_spoc_5_topics,\
-    mock_spoc_6_no_sponsor, mock_spoc_7_is_video
-from tests.fixtures.mock_decision import mock_decision_2, mock_decision_3_cta, mock_decision_5_topics,\
-    mock_decision_6_no_sponsor, mock_decision_7_is_video
+from tests.fixtures.mock_spoc import *
+from tests.fixtures.mock_decision import *
 
 
 class TestAdZerkTransform(TestCase):
@@ -30,6 +27,10 @@ class TestAdZerkTransform(TestCase):
     @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
     def test_to_spoc_is_video(self):
         self.assertEqual(mock_spoc_7_is_video, to_spoc(mock_decision_7_is_video))
+
+    @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
+    def test_to_spoc_is_video(self):
+        self.assertEqual(mock_spoc_8_blank_sponsored_by_override, to_spoc(mock_decision_8_blank_sponsored_by_override))
 
     def test_tracking_url_to_shim(self):
         self.assertEqual('0,eyJ,Zz', tracking_url_to_shim('https://e-10250.adzerk.net/r?e=eyJ&s=Zz'))


### PR DESCRIPTION
## Goal
Allow the 'sponsored by' label to be hidden for spocs coming from Mozilla or Pocket. We've chosen the keyword `blank` or `empty` to return an empty string for `sponsored_by_override`.

## Implementation Decisions


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
