### PR TITLE
Set spoc v2 feature flag

### DIFF
--- a/conf/spocs.py
+++ b/conf/spocs.py
@@ -11,6 +11,9 @@ production = development = {
         },
     },
     'settings': {
+        "feature_flags": {
+            "spoc_v2": True,
+        },
         "spocsPerNewTabs": 1,
         "domainAffinityParameterSets": {
             "default": {


### PR DESCRIPTION
## Goal
Introduce feature flags that allow us to remotely control whether an experimental feature is enabled. This can be used to quickly turn off a feature if it is not working as expected.

## Todos:
- [ ] Test on staging server

## Implementation Decisions
We might eventually want to fetch these values from an admin tool, but because this is time-sensitive I did something quick.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
