### PR TITLE
Disable spoc v2

### DIFF
--- a/conf/spocs.py
+++ b/conf/spocs.py
@@ -12,7 +12,7 @@ production = development = {
     },
     'settings': {
         "feature_flags": {
-            "spoc_v2": True,
+            "spoc_v2": False,
         },
         "spocsPerNewTabs": 1,
         "domainAffinityParameterSets": {


### PR DESCRIPTION
## Goal
Disable the spoc v2 experiment. The experiment branch causes low-priority spocs to be served over higher-priority ones, and was disruptive for the revenue team. We'll find solutions for the problems we ran into and run another experiment.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
