### PR TITLE
Fixed typo in prod deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
                 name: Setup common environment variables
                 command: |
                   echo "building for prod...main image name is $MAIN_IMAGE_NAME"
-                  echo 'export AWS_ECR_ACCOUNT_PROXY_URL="${ACCOUNT_ID_PROXY}.dkr.ecr.us-east-1.amazonaws.com"' >> $BASH_ENV
+                  echo 'export AWS_ECR_ACCOUNT_PROD_URL="${ACCOUNT_ID_PROXY}.dkr.ecr.us-east-1.amazonaws.com"' >> $BASH_ENV
                   echo 'export AWS_ECR_ACCOUNT_URL="${AWS_ECR_ACCOUNT_PROD_URL}"' >> $BASH_ENV
             - assume-role/assume-role:
                 account-id: $ACCOUNT_ID_PROXY


### PR DESCRIPTION
## Goal
Fix typo that failed deployment to prod:
```
invalid argument "/proxy:6e3535cfa7de463a0b1e19b0fe2187acc37f2603" for "-t, --tag" flag: invalid reference format
```

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
