### PR TITLE
Add new field 'priority'

### DIFF
--- a/adzerk/api.py
+++ b/adzerk/api.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import conf
 import adzerk.validation
 import adzerk.secret
+import random
 import time
 
 
@@ -16,7 +17,7 @@ class AdZerkException(Exception):
 class Api:
     # Cache AdZerk priorities for this many seconds
     PRIORITY_CACHE_DURATION = 3600
-    priority_cache_expires_at = None
+    priority_cache_expires_at = time.time() + random.uniform(0, PRIORITY_CACHE_DURATION)
 
     def __init__(self, pocket_id, country=None, region=None, site=None, placements=None):
         self.pocket_id = pocket_id

--- a/adzerk/api.py
+++ b/adzerk/api.py
@@ -6,9 +6,17 @@ from copy import deepcopy
 import conf
 import adzerk.validation
 import adzerk.secret
+import time
+
+
+class AdZerkException(Exception):
+    pass
 
 
 class Api:
+    # Cache AdZerk priorities for this many seconds
+    PRIORITY_CACHE_DURATION = 3600
+    priority_cache_expires_at = None
 
     def __init__(self, pocket_id, country=None, region=None, site=None, placements=None):
         self.pocket_id = pocket_id
@@ -83,10 +91,39 @@ class Api:
 
         return response
 
+    def get_cached_priorty_id_to_weights(self):
+        if Api.priority_cache_expires_at is None or Api.priority_cache_expires_at <= time.time():
+            try:
+                conf.adzerk['priority_id_to_weight'] = self.get_priority_id_to_weights()
+                Api.priority_cache_expires_at = time.time() + Api.PRIORITY_CACHE_DURATION
+            except AdZerkException as e:
+                logging.error(f"Failed to refresh AdZerk priorities: {e}")
+
+        return conf.adzerk['priority_id_to_weight']
+
+    def get_priority_id_to_weights(self):
+        response = self.__get_priorities()
+        if response.status_code == 401:
+            self.__update_api_key()
+            response = self.__get_priorities()
+
+        if response.status_code != 200:
+            raise AdZerkException(f"{response.status_code} get_priorities: {response.text}")
+        else:
+            data = response.json()
+            return {priority['Id']: priority['Weight'] for priority in data['items']}
+
     def __request_delete_user(self):
         return requests.delete(
             url=conf.adzerk['forget_endpoint'],
             params={'userKey': self.pocket_id},
+            headers={'X-Adzerk-ApiKey': conf.adzerk['api_key']},
+            timeout=30
+        )
+
+    def __get_priorities(self):
+        return requests.get(
+            url=conf.adzerk['get_priority_endpoint'],
             headers={'X-Adzerk-ApiKey': conf.adzerk['api_key']},
             timeout=30
         )

--- a/adzerk/transform.py
+++ b/adzerk/transform.py
@@ -7,6 +7,9 @@ import distutils.util
 import conf
 
 
+DEFAULT_PRIORITY = 100
+
+
 def to_spoc(decision):
     if not decision:
         return {}
@@ -25,6 +28,7 @@ def to_spoc(decision):
         'url':                    custom_data['ctUrl'],
         'domain':                 custom_data['ctDomain'],
         'excerpt':                custom_data['ctExcerpt'],
+        'priority':               conf.adzerk['priority_id_to_weight'].get(decision.get('priorityId'), DEFAULT_PRIORITY),
         'context':                __get_context(custom_data.get('ctSponsor')),
         'raw_image_src':          custom_data['ctFullimagepath'],
         'image_src':              __get_cdn_image(custom_data['ctFullimagepath']),

--- a/adzerk/transform.py
+++ b/adzerk/transform.py
@@ -5,7 +5,7 @@ import logging
 import distutils.util
 
 import conf
-
+from adzerk.api import Api
 
 DEFAULT_PRIORITY = 100
 
@@ -19,6 +19,8 @@ def to_spoc(decision):
         body = json.loads(body)
 
     events_map = {e["id"]: tracking_url_to_shim(e["url"]) for e in decision["events"]}
+    adzerk_api = Api(pocket_id=None)
+    priority_map = adzerk_api.get_cached_priorty_id_to_weights()
 
     spoc = {
         'id':                     decision['adId'],
@@ -28,7 +30,7 @@ def to_spoc(decision):
         'url':                    custom_data['ctUrl'],
         'domain':                 custom_data['ctDomain'],
         'excerpt':                custom_data['ctExcerpt'],
-        'priority':               conf.adzerk['priority_id_to_weight'].get(decision.get('priorityId'), DEFAULT_PRIORITY),
+        'priority':               priority_map.get(decision.get('priorityId'), DEFAULT_PRIORITY),
         'context':                __get_context(custom_data.get('ctSponsor')),
         'raw_image_src':          custom_data['ctFullimagepath'],
         'image_src':              __get_cdn_image(custom_data['ctFullimagepath']),

--- a/conf/adzerk.py
+++ b/conf/adzerk.py
@@ -30,6 +30,15 @@ default = {
                 "eventIds": [17, 20],
             }]
         }
+    },
+    # These are hardcoded and not expected to change.
+    # If they do end up changing, we should fetch them from https://api.adzerk.net/v1/priority.
+    "priority_id_to_weight": {
+        147517: 1,
+        180843: 2,
+        147518: 3,
+        160722: 9,
+        147520: 10,
     }
 }
 

--- a/conf/adzerk.py
+++ b/conf/adzerk.py
@@ -33,6 +33,14 @@ default = {
             }]
         }
     },
+    # Default priory_id to weight mapping, used during task startup before they are fetched from AdZerk.
+    "priority_id_to_weight": {
+        147517: 1,
+        180843: 2,
+        147518: 3,
+        160722: 9,
+        147520: 10,
+    }
 }
 
 production = deepcopy(default)

--- a/conf/adzerk.py
+++ b/conf/adzerk.py
@@ -33,15 +33,6 @@ default = {
             }]
         }
     },
-    # These are hardcoded and not expected to change.
-    # If they do end up changing, we should fetch them from https://api.adzerk.net/v1/priority.
-    "priority_id_to_weight": {
-        147517: 1,
-        180843: 2,
-        147518: 3,
-        160722: 9,
-        147520: 10,
-    }
 }
 
 production = deepcopy(default)

--- a/conf/adzerk.py
+++ b/conf/adzerk.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 
 from telemetry.handler import TELEMETRY_PATH_IDS
 import adzerk.secret
+import adzerk.api
 from conf import env
 
 network_id = 10250
@@ -17,6 +18,7 @@ default = {
     "div_name": div_name,
     "telemetry_endpoint_ids": TELEMETRY_PATH_IDS,
     "forget_endpoint": "{0}/udb/{1}/".format(domain, str(network_id)),
+    "get_priority_endpoint": "https://api.adzerk.net/v1/priority",
     "decision": {
         "url": "{0}/api/v2".format(domain),
         "body": {

--- a/tests/fixtures/mock_decision.py
+++ b/tests/fixtures/mock_decision.py
@@ -117,7 +117,7 @@ mock_decision_2 = {
   "creativeId": 9142593,
   "flightId": 8525375,
   "campaignId": 887195,
-  "priorityId": 155142,
+  "priorityId": 147517,
   "clickUrl": "https://e-10250.adzerk.net/r?e=jq&s=s2",
   "impressionUrl": "https://e-10250.adzerk.net/i.gif?e=ke1&s=s3",
   "contents": [
@@ -178,3 +178,7 @@ mock_decision_8_blank_sponsored_by_override['contents'][0]['data']['ctSponsoredB
 mock_decision_9_sponsored_by_override = deepcopy(mock_decision_2)
 mock_decision_9_sponsored_by_override['adId'] = 9
 mock_decision_9_sponsored_by_override['contents'][0]['data']['ctSponsoredByOverride'] = "Brought by blank"
+
+mock_decision_10_missing_priority = deepcopy(mock_decision_2)
+mock_decision_10_missing_priority['adId'] = 10
+mock_decision_10_missing_priority['priorityId'] = 147520

--- a/tests/fixtures/mock_decision.py
+++ b/tests/fixtures/mock_decision.py
@@ -181,4 +181,4 @@ mock_decision_9_sponsored_by_override['contents'][0]['data']['ctSponsoredByOverr
 
 mock_decision_10_missing_priority = deepcopy(mock_decision_2)
 mock_decision_10_missing_priority['adId'] = 10
-mock_decision_10_missing_priority['priorityId'] = 147520
+del mock_decision_10_missing_priority['priorityId']

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -79,4 +79,4 @@ mock_spoc_9_sponsored_by_override["sponsored_by_override"] = "Brought by blank"
 
 mock_spoc_10_missing_priority = deepcopy(mock_spoc_2)
 mock_spoc_10_missing_priority["id"] = 10
-mock_spoc_10_missing_priority["priority"] = 10
+mock_spoc_10_missing_priority["priority"] = 100

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -8,6 +8,7 @@ mock_spoc_2 = {
     "url": "https://example.com/?key=foobar",
     "domain": "wallmarket.com",
     "excerpt": "Get up to 50% off furniture, bedding, and more.",
+    "priority": 1,
     "context": "Sponsored by WallMarket",
     "sponsor": "WallMarket",
     "raw_image_src": "https://cdn.net/25a.jpg",
@@ -75,3 +76,7 @@ mock_spoc_8_blank_sponsored_by_override["sponsored_by_override"] = ""
 mock_spoc_9_sponsored_by_override = deepcopy(mock_spoc_2)
 mock_spoc_9_sponsored_by_override["id"] = 9
 mock_spoc_9_sponsored_by_override["sponsored_by_override"] = "Brought by blank"
+
+mock_spoc_10_missing_priority = deepcopy(mock_spoc_2)
+mock_spoc_10_missing_priority["id"] = 10
+mock_spoc_10_missing_priority["priority"] = 10

--- a/tests/unit/test_adzerk_api.py
+++ b/tests/unit/test_adzerk_api.py
@@ -139,8 +139,9 @@ class TestAdZerkApi(TestCase):
         url = 'https://api.adzerk.net/v1/priority'
         responses.add(responses.GET, url, status=200, body='{"items": [{"Id": 123, "Weight": 9}]}')
 
+        api = Api(pocket_id=None)
+
         for i in range(20):
-            api = Api(pocket_id=None)
             result = api.get_cached_priorty_id_to_weights()
             self.assertEqual({123: 9}, result)
 

--- a/tests/unit/test_adzerk_api.py
+++ b/tests/unit/test_adzerk_api.py
@@ -1,12 +1,17 @@
 from unittest import TestCase
 from unittest.mock import patch
 import responses
+import time
 
 from adzerk.api import Api
 from tests.fixtures.mock_placements import mock_placements, mock_spocs_placement
 
 
 class TestAdZerkApi(TestCase):
+
+    def setUp(self):
+        # Reset cache expiration time
+        Api.priority_cache_expires_at = None
 
     @patch.dict('conf.adzerk', {"api_key": "DUMMY_123"})
     @responses.activate
@@ -89,4 +94,55 @@ class TestAdZerkApi(TestCase):
         body = api.get_decision_body()
         self.assertEqual(1070098, body['placements'][0]['siteId'])
 
+    @patch.dict('conf.adzerk', {"api_key": "DUMMY_123"})
+    @patch('adzerk.secret.get_api_key', return_value="DUMMY_123")
+    @responses.activate
+    def test_get_priorities(self, mock_get_api_key):
+        url = 'https://api.adzerk.net/v1/priority'
+        responses.add(responses.GET, url, status=200, body='{"items": [{"Id": 123, "Weight": 9}]}')
 
+        api = Api(pocket_id=None)
+        result = api.get_cached_priorty_id_to_weights()
+
+        self.assertEqual({123: 9}, result)
+
+        # Check that the cache expiration time was updated correctly, with 1 second precision.
+        self.assertAlmostEqual(
+            api.priority_cache_expires_at,
+            time.time() + api.PRIORITY_CACHE_DURATION,
+            delta=1.0)
+
+        self.assertEqual(1, len(responses.calls))
+
+        request = responses.calls[0].request
+        self.assertEqual(url, request.url)
+        self.assertEqual('DUMMY_123', request.headers['X-Adzerk-ApiKey'])
+
+    @patch.dict('conf.adzerk', {"api_key": "DUMMY_123"})
+    @patch('adzerk.secret.get_api_key', return_value="DUMMY_123")
+    @responses.activate
+    def test_get_priorities_retries_on_401(self, mock_get_api_key):
+        url = 'https://api.adzerk.net/v1/priority'
+        responses.add(responses.GET, url, status=401, body='')
+        responses.add(responses.GET, url, status=200, body='{"items": [{"Id": 123, "Weight": 9}]}')
+
+        api = Api(pocket_id=None)
+        result = api.get_cached_priorty_id_to_weights()
+
+        self.assertEqual({123: 9}, result)
+        self.assertEqual(2, len(responses.calls))
+
+    @patch.dict('conf.adzerk', {"api_key": "DUMMY_123"})
+    @patch('adzerk.secret.get_api_key', return_value="DUMMY_123")
+    @responses.activate
+    def test_get_priorities_cache(self, mock_get_api_key):
+        url = 'https://api.adzerk.net/v1/priority'
+        responses.add(responses.GET, url, status=200, body='{"items": [{"Id": 123, "Weight": 9}]}')
+
+        for i in range(20):
+            api = Api(pocket_id=None)
+            result = api.get_cached_priorty_id_to_weights()
+            self.assertEqual({123: 9}, result)
+
+        # Check that only a single request is made to AdZerk.
+        self.assertEqual(1, len(responses.calls))

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -42,7 +42,7 @@ class TestAdZerkTransform(TestCase):
         self.assertEqual(mock_spoc_9_sponsored_by_override, to_spoc(mock_decision_9_sponsored_by_override))
 
     @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
-    def test_to_collection(self):
+    def test_missing_priority_id(self):
         self.assertEqual(mock_spoc_10_missing_priority, to_spoc(mock_decision_10_missing_priority))
 
     def test_tracking_url_to_shim(self):

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -9,6 +9,13 @@ import conf
 
 
 class TestAdZerkTransform(TestCase):
+    def setUp(self):
+        self.patcher = patch('adzerk.api.Api.get_cached_priorty_id_to_weights', return_value={147517: 1})
+        self.mock_object = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
     @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
     def test_to_spoc(self):
         self.assertEqual(mock_spoc_2, to_spoc(mock_decision_2))
@@ -72,7 +79,8 @@ class TestAdZerkTransform(TestCase):
             {'arts_and_entertainment':1},
             get_personalization_models({'other_property_business': 'true', 'topic_arts_and_entertainment': 'true'}))
 
-    def test_priority_to_weight(self):
+    def test_fallback_priority_to_weight(self):
+        # Test that AdZerk priorities are set in conf, without having to fetch them from AdZerk.
         priority_id_to_weight = conf.adzerk['priority_id_to_weight']
         self.assertEqual(1, priority_id_to_weight[147517])
         self.assertEqual(3, priority_id_to_weight[147518])

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -78,12 +78,3 @@ class TestAdZerkTransform(TestCase):
         self.assertEqual(
             {'arts_and_entertainment':1},
             get_personalization_models({'other_property_business': 'true', 'topic_arts_and_entertainment': 'true'}))
-
-    def test_fallback_priority_to_weight(self):
-        # Test that AdZerk priorities are set in conf, without having to fetch them from AdZerk.
-        priority_id_to_weight = conf.adzerk['priority_id_to_weight']
-        self.assertEqual(1, priority_id_to_weight[147517])
-        self.assertEqual(3, priority_id_to_weight[147518])
-        self.assertEqual(10, priority_id_to_weight[147520])
-        self.assertEqual(9, priority_id_to_weight[160722])
-        self.assertEqual(2, priority_id_to_weight[180843])

--- a/tests/unit/test_adzerk_transform.py
+++ b/tests/unit/test_adzerk_transform.py
@@ -5,6 +5,7 @@ from adzerk.transform import \
     to_spoc, tracking_url_to_shim, is_collection, to_collection, get_personalization_models
 from tests.fixtures.mock_spoc import *
 from tests.fixtures.mock_decision import *
+import conf
 
 
 class TestAdZerkTransform(TestCase):
@@ -32,6 +33,10 @@ class TestAdZerkTransform(TestCase):
     def test_to_spoc_sponsored_by_override(self):
         self.assertEqual(mock_spoc_8_blank_sponsored_by_override, to_spoc(mock_decision_8_blank_sponsored_by_override))
         self.assertEqual(mock_spoc_9_sponsored_by_override, to_spoc(mock_decision_9_sponsored_by_override))
+
+    @patch.dict('conf.domain_affinities', {"publishers": {'example.com': 1}})
+    def test_to_collection(self):
+        self.assertEqual(mock_spoc_10_missing_priority, to_spoc(mock_decision_10_missing_priority))
 
     def test_tracking_url_to_shim(self):
         self.assertEqual('0,eyJ,Zz', tracking_url_to_shim('https://e-10250.adzerk.net/r?e=eyJ&s=Zz'))
@@ -66,3 +71,11 @@ class TestAdZerkTransform(TestCase):
         self.assertEqual(
             {'arts_and_entertainment':1},
             get_personalization_models({'other_property_business': 'true', 'topic_arts_and_entertainment': 'true'}))
+
+    def test_priority_to_weight(self):
+        priority_id_to_weight = conf.adzerk['priority_id_to_weight']
+        self.assertEqual(1, priority_id_to_weight[147517])
+        self.assertEqual(3, priority_id_to_weight[147518])
+        self.assertEqual(10, priority_id_to_weight[147520])
+        self.assertEqual(9, priority_id_to_weight[160722])
+        self.assertEqual(2, priority_id_to_weight[180843])

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -67,8 +67,7 @@ class TestApp(unittest.TestCase):
 
     @patch('provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('adzerk.api.Api.get_decisions', return_value=mock_response_map)
-    @responses.activate
-    def test_app_spocs_production_valid(self, mock_geo, mock_adzerk):
+    def test_app_spocs_production_valid_with_country_region(self, mock_geo, mock_adzerk):
         country_region = {
             'country': 'CA',
             'region': 'ON',

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 from copy import deepcopy
+import responses
 
 from app.main import create_app
 from tests.fixtures.mock_decision import mock_response, mock_response_900, mock_collection_response
@@ -15,6 +16,13 @@ class TestApp(unittest.TestCase):
     mock_response_map = {'default': [mock_response]}
     mock_placement_map = {'top-sites': [mock_response], 'text-promo': [mock_response_900]}
     mock_collection_placement_map = {'sponsored-collection': [mock_collection_response], 'spocs': [mock_response]}
+
+    def setUp(self):
+        self.patcher = patch('adzerk.api.Api.get_cached_priorty_id_to_weights', return_value={147517: 1})
+        self.mock_object = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
 
     @classmethod
     def create_client_no_geo_locs(cls):
@@ -59,6 +67,7 @@ class TestApp(unittest.TestCase):
 
     @patch('provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('adzerk.api.Api.get_decisions', return_value=mock_response_map)
+    @responses.activate
     def test_app_spocs_production_valid(self, mock_geo, mock_adzerk):
         country_region = {
             'country': 'CA',


### PR DESCRIPTION
## Goal
This returns the weight of AdZerk's priorities. Priorities are designated by a number: 1 is the highest priority while 100 is lowest.

## Implementation Decisions
- This is a quick solution to refresh priorities. A better solution would be to have a shared cache that is updated using a Lambda, such that we're only making one request to AdZerk per hour. Even better would be if AdZerk's API would allow us to specify which fields we would like to get back, so we wouldn't have to manage this state ourselves.
- If the priority is not set, we return the lowest priority value of 100.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
