### PR TITLE
Increase Kevel Timeout

### DIFF
--- a/app/adzerk/api.py
+++ b/app/adzerk/api.py
@@ -28,7 +28,7 @@ class Api:
         :return: A map of decisions, previously
         a list of decisions for one div/placement.
         """
-        timeout = aiohttp.ClientTimeout(total=0.5)
+        timeout = aiohttp.ClientTimeout(total=1)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(conf.adzerk['decision']['url'], json=self.get_decision_body()) as r:
                 response = await r.json()


### PR DESCRIPTION
## Goal

There are a number of 5xx errors since moving to fastapi. All the errors https://sentry.prod.mozaws.net/operations/proxyserver/issues/10489778/?query=is%3Aunresolved point to a timeout in the decision API from level. 

The theory is that the switch to aiohttp was not 1:1 with timeout values. However, the Kevel should never take longer than a second to respond.

## Todos:
- [x] Increase timeout


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
