### PR TITLE
increasing aiohttp timeout to 5 seconds

### DIFF
--- a/app/adzerk/api.py
+++ b/app/adzerk/api.py
@@ -28,7 +28,7 @@ class Api:
         :return: A map of decisions, previously
         a list of decisions for one div/placement.
         """
-        timeout = aiohttp.ClientTimeout(total=1)
+        timeout = aiohttp.ClientTimeout(total=5)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(conf.adzerk['decision']['url'], json=self.get_decision_body()) as r:
                 response = await r.json()


### PR DESCRIPTION
## Goal

Based on https://github.com/aio-libs/aiohttp/issues/4015#issuecomment-526108921 we are increasing the timeout in aiohttp. The theory is that requests in synchronous while aiohttp does more advanced metrics.

## Todos:
- [x] Increase to 5 seconds

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
