### PR TITLE
updating timeout to 30 seconds

### DIFF
--- a/app/adzerk/api.py
+++ b/app/adzerk/api.py
@@ -28,7 +28,7 @@ class Api:
         :return: A map of decisions, previously
         a list of decisions for one div/placement.
         """
-        timeout = aiohttp.ClientTimeout(total=5)
+        timeout = aiohttp.ClientTimeout(total=30)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(conf.adzerk['decision']['url'], json=self.get_decision_body()) as r:
                 response = await r.json()


### PR DESCRIPTION
## Goal

Updating our timeout to 5 seconds decreased our number of 5xx errors. This proves that aiohttp timeouts operate differently than requests. To compensate we are increasing to 30 seconds.

## Todos:
- [x] Update to 30 sec


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
