### PR TITLE
Remove the limit on aiohttp connections

### DIFF
--- a/app/adzerk/api.py
+++ b/app/adzerk/api.py
@@ -29,7 +29,8 @@ class Api:
         a list of decisions for one div/placement.
         """
         timeout = aiohttp.ClientTimeout(total=30)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        connector = aiohttp.TCPConnector(limit=None)
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
             async with session.post(conf.adzerk['decision']['url'], json=self.get_decision_body()) as r:
                 response = await r.json()
 


### PR DESCRIPTION
## Goal

Based on reading from https://docs.aiohttp.org/en/latest/http_request_lifecycle.html it looks like the aiohttp session was being re-used behind the scenes. The default behavior here is that when the session hits 100 connections all other connections will be put in a queue system and wait their turn. This correlated to exactly 100 breadcrumbs making a request in a sentry error.

## Todos:
- [ ] Load test on dev to confirm

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
