### PR TITLE
Fix Sentry Integration & Decisions API Response

### DIFF
--- a/app/adzerk/api.py
+++ b/app/adzerk/api.py
@@ -32,6 +32,12 @@ class Api:
         connector = aiohttp.TCPConnector(limit=None)
         async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
             async with session.post(conf.adzerk['decision']['url'], json=self.get_decision_body()) as r:
+                if r.status == 400:
+                    text = await r.text()
+                    # This occurs when there is no site with the requested id from adzerk.
+                    # So instead we send back no results but log an error
+                    logging.error(text)
+                    return dict()
                 response = await r.json()
 
         decisions = response['decisions']

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from json.decoder import JSONDecodeError
 from os import environ
 import sentry_sdk
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 import uvicorn
 from starlette.responses import JSONResponse
 from fastapi import FastAPI, Request
@@ -23,6 +24,7 @@ sentry_sdk.init(
 )
 
 app = FastAPI()
+app.add_middleware(SentryAsgiMiddleware)
 
 # Trust the X-Forwarded-For using a middleware. See the middle ware for more info.
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")

--- a/images/app/Dockerfile
+++ b/images/app/Dockerfile
@@ -1,8 +1,9 @@
+ARG GIT_SHA=local
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7 as base
 
 # Based on https://sourcery.ai/blog/python-docker/
 FROM base AS python-deps
-ARG GIT_SHA=local
+ARG GIT_SHA
 
 # Install pipenv
 RUN pip install pipenv
@@ -12,11 +13,11 @@ WORKDIR /
 COPY Pipfile .
 COPY Pipfile.lock .
 ENV PIPENV_VENV_IN_PROJECT=1
-RUN echo "GIT_SHA=${GIT_SHA}"
 RUN if [ "$GIT_SHA" = "local" ]; then pipenv install --dev; else pipenv install --deploy; fi
 
 
 FROM base AS runtime
+ARG GIT_SHA
 
 # Copy virtual env from python-deps stage
 COPY --from=python-deps /.venv /.venv


### PR DESCRIPTION
## Goal

We are getting a lot of:

```
0, message='Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8', url=URL('https://e-site-id.adzerk.net/api/v2')
```

Looks like this is because clients are requesting sites with no ads to be served. Instead, we should log the error and return no ads to the clients.

## Todos:
- [x] Add the Sentry ASGI integration
- [x] Fix the GITSHA in the dockerbuild file
- [x] Return an empty dict when adzerk sends a bad request and log it.

## Implementation Decisions


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
