### PR TITLE
Decrease placement count from 20 to 10

### DIFF
--- a/app/conf/adzerk.py
+++ b/app/conf/adzerk.py
@@ -18,7 +18,7 @@ production = staging = development = test = {
                 "siteId": 1070098,
                 "adTypes": [2401, 3617],
                 "zoneIds": [217995],
-                "count": 20,
+                "count": 10,
                 "eventIds": [17, 20],
             }]
         }

--- a/tests/unit/test_adzerk_api.py
+++ b/tests/unit/test_adzerk_api.py
@@ -63,7 +63,7 @@ class TestAdZerkApi(TestCase):
         for p in body['placements']:
             self.assertEqual(10250, p['networkId'])
             self.assertEqual(1070098, p['siteId'])
-            self.assertEqual(20, p['count'])
+            self.assertEqual(10, p['count'])
             self.assertEqual([5000], p['zoneIds'])
 
     def test_default_zone(self):


### PR DESCRIPTION
## Goal
Decrease the number of ads requested by default from 20 to 10, to accomplish two goals:
1. Improve stability, by avoiding big jumps in the request size, which require a scale-out. (See figure below.)
2. This was a request from ad-ops, because it might help with pacing: https://pocket.slack.com/archives/C01DGLNSFK9/p1612462133011500


![Screenshot from 2021-03-17 17-31-39](https://user-images.githubusercontent.com/1547251/111555939-a9bb0a80-8746-11eb-92b1-dd56115c57f2.png)

## Implementation Decisions
Alternative solutions:
- Scale out faster when CPU is very high. Currently it takes 5 scale-out events over the course of 20 minutes to sufficiently decrease CPU usage.
- Solve the underlying performance problem, that makes the server sensitive to request size. This thread in FastAPI might be related: https://github.com/tiangolo/fastapi/issues/360#issuecomment-537839990

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
