### PR TITLE
Add collections feature flag

### DIFF
--- a/app/conf/spocs.py
+++ b/app/conf/spocs.py
@@ -13,6 +13,8 @@ production = staging = development = test = {
     'settings': {
         "feature_flags": {
             "spoc_v2": True,
+            # If collections is True, the client can include a collection placement in the request.
+            # If collections is False, the client will not include a collection placement, to reduce ad decisions.
             "collections": False,
         },
         "spocsPerNewTabs": 1,

--- a/app/conf/spocs.py
+++ b/app/conf/spocs.py
@@ -13,6 +13,7 @@ production = staging = development = test = {
     'settings': {
         "feature_flags": {
             "spoc_v2": True,
+            "collections": False,
         },
         "spocsPerNewTabs": 1,
         "domainAffinityParameterSets": {

--- a/app/conf/spocs.py
+++ b/app/conf/spocs.py
@@ -13,6 +13,7 @@ production = staging = development = test = {
     'settings': {
         "feature_flags": {
             "spoc_v2": True,
+            # 'Collections' are stories that are run together, currently only used occasionally in Firefox.
             # If collections is True, the client can include a collection placement in the request.
             # If collections is False, the client will not include a collection placement, to reduce ad decisions.
             "collections": False,


### PR DESCRIPTION
## Goal
Give us control over whether collections are enabled, in order to decrease the number of ad decisions we need to make.

Collections in this context are a set of 3 or more stories that are run together on the Firefox New Tab. We only rarely run collections, but currently we're always requesting ad decisions for them.

## Implementation Decisions
- Specifying feature flags in code is low effort and guarantees good performance, but the approach will break down when this feature flag will have to be changed frequently. Currently that's not anticipated.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

## Reference
Slack thread:
- https://pocket.slack.com/archives/C4LD0T132/p1626449573016400
