### PR TITLE
fix: update spoc template transformation

### DIFF
--- a/app/adzerk/transform.py
+++ b/app/adzerk/transform.py
@@ -56,11 +56,8 @@ def to_spoc(decision):
     if 'sponsored_by_override' in spoc:
         spoc['sponsored_by_override'] = __clean_sponsored_by_override(spoc['sponsored_by_override'])
 
-    try:
-        spoc['min_score']  = float(custom_data['ctMin_score'])
-        spoc['item_score'] = float(custom_data['ctItem_score'])
-    except (KeyError, ValueError) as e:
-        logging.warning(str(e))
+    spoc['min_score'] = float(custom_data.get('ctMin_score', 0.1))
+    spoc['item_score'] = float(custom_data.get('ctItem_score', 0.2))
 
     try:
         spoc['is_video'] = bool(distutils.util.strtobool(custom_data['ctIsVideo'].strip()))

--- a/tests/fixtures/mock_decision.py
+++ b/tests/fixtures/mock_decision.py
@@ -126,9 +126,7 @@ mock_decision_2 = {
       "data": {
         "ctUrl": "https://example.com/?key=foobar",
         "ctDomain_affinities": "publishers",
-        "ctMin_score": "0.1",
         "ctDomain": "wallmarket.com",
-        "ctItem_score": "0.11",
         "ctTitle": "Refresh Your Space for Spring",
         "ctExcerpt": "Get up to 50% off furniture, bedding, and more.",
         "ctFullimagepath": "https://cdn.net/25a.jpg",

--- a/tests/fixtures/mock_spoc.py
+++ b/tests/fixtures/mock_spoc.py
@@ -36,7 +36,7 @@ mock_spoc_2 = {
     },
     "personalization_models": {},
     "min_score": 0.1,
-    "item_score": 0.11,
+    "item_score": 0.2,
 }
 
 mock_spoc_3_cta = deepcopy(mock_spoc_2)


### PR DESCRIPTION
## Goal

Update adzerk spoc template transformation. 

- Set default `min_score` = `0.1`
- Set default `item_score` = `0.2`

## Implementation Decisions
Opted to leave optional properties `domain_affinities` and `cta` untouched.

## Reference
Slack: https://pocket.slack.com/archives/CR6T8BNCT/p1635287235002800
Ticket: https://getpocket.atlassian.net/browse/INFRA-148

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
