### PR TITLE
chore(nginx): Upgrade to an nginx getting security updates

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17
+FROM nginx:1.21
 
 RUN apt-get update && \
     apt-get install -y curl


### PR DESCRIPTION
## Goal

Support ended for this version of nginx, bumping to include security updates.

https://mozilla-hub.atlassian.net/browse/POC-63

https://endoflife.date/nginx

