### PR TITLE
chore(nginx): POC-87 update server configuration

### DIFF
--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -26,7 +26,7 @@ http {
     #server unix:/tmp/gunicorn.sock fail_timeout=0;
 
     # for a TCP configuration
-    server app:8000 fail_timeout=0;
+    server 127.0.0.1:8000 fail_timeout=0;
   }
 
   server {


### PR DESCRIPTION
## Goal

This was broken in 7c641327, since this isn't automatically deployed I am assuming we never noticed. If you try to start a new nginx image with that configuration it will error with:

```bash
2022/03/28 18:52:07 [emerg] 1#1: host not found in upstream "app:8000" in /etc/nginx/nginx.conf:29
nginx: [emerg] host not found in upstream "app:8000" in /etc/nginx/nginx.conf:29          
```
