### PR TITLE
chore(sentry): [BACK-1573] Remove Sentry from Proxy Server

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ fastapi = "*"
 uvloop = "*"
 httptools = "*"
 aiohttp = {extras = ["speedups"], version = "*"}
-# Note that this dependency  even though Sentry has been removed from the code.
+# Note that this dependency remains even though Sentry has been removed from the code.
 # Attempting to remove it updates many of the other packages that were last updated
 # in July 2020 and it's too much change to test/monitor for not much benefit.
 sentry-sdk = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,9 @@ fastapi = "*"
 uvloop = "*"
 httptools = "*"
 aiohttp = {extras = ["speedups"], version = "*"}
+# Note that this dependency  even though Sentry has been removed from the code.
+# Attempting to remove it updates many of the other packages that were last updated
+# in July 2020 and it's too much change to test/monitor for not much benefit.
 sentry-sdk = "*"
 
 [dev-packages]

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ The following steps create a Docker development environment to run this service 
         ```
         aws --endpoint-url http://localhost:4569 s3 cp GeoLite2-City.mmdb s3://pocket-geoip/GeoIP2-City.mmdb
         ```
-4. Verify that GeoIP2 is available at [localhost:4569/pocket-geoip/GeoIP2-City.mmdb](http://localhost:4569/pocket-geoip/GeoIP2-City.mmdb).
-5. Create a `.env` file in the project root directory with the following content, replacing `<secret>` with the respective secret values:
+5. Verify that GeoIP2 is available at [localhost:4569/pocket-geoip/GeoIP2-City.mmdb](http://localhost:4569/pocket-geoip/GeoIP2-City.mmdb).
+6. Create a `.env` file in the project root directory with the following content, replacing `<secret>` with the respective secret values:
     ```
     SENTRY_DSN=<secret>
     ADZERK_API_KEY=<secret>
     ```
-6. Start the application containers: `docker-compose up`.
-7. Test that the application is running: http://localhost/pulse. It should return `{"pulse":"ok"}`.
+7. Start the application containers: `docker-compose up`.
+8. Test that the application is running: http://localhost/pulse. It should return `{"pulse":"ok"}`.
 
 ## Tests
 See the [Test README](tests/README.md).
@@ -47,7 +47,7 @@ For subsequent deployments:
    they should pull in your changes without forcing an update to the task.
 
 # Telemetry Function
-The [Telemtry Handler](app/telemetry/handler.py) is triggered by telemetry from the Firefox discovery stream. It anonymously pings AdZerk to keep track of events related to sponsored content, such as clicks and impressions, in a privacy-preserving way. The event code (or "shim") does not contain any personally identifiable data; we never share personal data with AdZerk.
+The [Telemetry Handler](app/telemetry/handler.py) is triggered by telemetry from the Firefox discovery stream. It anonymously pings AdZerk to keep track of events related to sponsored content, such as clicks and impressions, in a privacy-preserving way. The event code (or "shim") does not contain any personally identifiable data; we never share personal data with AdZerk.
 
 ## Deployment
  

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The following steps create a Docker development environment to run this service 
 5. Verify that GeoIP2 is available at [localhost:4569/pocket-geoip/GeoIP2-City.mmdb](http://localhost:4569/pocket-geoip/GeoIP2-City.mmdb).
 6. Create a `.env` file in the project root directory with the following content, replacing `<secret>` with the respective secret values:
     ```
-    SENTRY_DSN=<secret>
     ADZERK_API_KEY=<secret>
     ```
 7. Start the application containers: `docker-compose up`.

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,5 @@
 from json.decoder import JSONDecodeError
 from os import environ
-import sentry_sdk
-from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 import uvicorn
 from starlette.responses import JSONResponse
 from fastapi import FastAPI, Request
@@ -17,14 +15,7 @@ from app.provider.geo_provider import GeolocationProvider
 from typing import Dict
 from app.middleware.proxy_headers import ProxyHeadersMiddleware
 
-sentry_sdk.init(
-    dsn=environ.get('SENTRY_DSN'),
-    environment=app.conf.env,
-    release=app.conf.release
-)
-
 app = FastAPI()
-app.add_middleware(SentryAsgiMiddleware)
 
 # Trust the X-Forwarded-For using a middleware. See the middle ware for more info.
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -2,6 +2,5 @@ Notes:
 
 - Log groups are not created by ecs-fargate.yaml. Including log groups in the templates proved to cause stack update reliability problems. You must manually create them before deploying.
 - You must manually create the GeoIP S3 bucket and upload GeoIP2-City.mmdb
-- You must manually create two secrets in a JSON object, which the SecretsManager AWS Console uses by default.
+- You must manually create a secret in a JSON object, which the SecretsManager AWS Console uses by default.
    - `prod/adzerk` that stores the AdZerk API key: `{"ADZERK_API_KEY":"<api key goes here>"}`
-   - `prod/sentry_dsn` that stores the Sentry DSN API key: `{"SENTRY_DSN":"<DSN goes here>"}`

--- a/cloudformation/proxy-service.yaml
+++ b/cloudformation/proxy-service.yaml
@@ -67,10 +67,6 @@ Parameters:
     Type: String
     Default: prod/adzerk
 
-  EcsAppSentryDsnSecretName:
-    Type: String
-    Default: prod/sentry_dsn
-
   ServiceScaleEvaluationPeriods:
     Description: "The number of periods over which data is compared to the specified threshold"
     Type: Number
@@ -227,8 +223,6 @@ Resources:
               HardLimit: 16384
 
           Secrets:
-            - Name: SENTRY_DSN
-              ValueFrom: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${EcsAppSentryDsnSecretName}:SENTRY_DSN::"
             - Name: ADZERK_API_KEY
               ValueFrom: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${EcsAppAdzerkSecretName}:ADZERK_API_KEY::"
 
@@ -292,7 +286,6 @@ Resources:
                   - secretsmanager:GetSecretValue
                 Resource:
                   - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${EcsAppAdzerkSecretName}-??????"
-                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${EcsAppSentryDsnSecretName}-??????"
 
   EcsTaskRole:
     Type: AWS::IAM::Role

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     environment:
       - APP_ENV=development
       - GEOIP_S3_BUCKET=pocket-geoip
-      - SENTRY_DSN=${SENTRY_DSN}
       - ADZERK_API_KEY=${ADZERK_API_KEY}
     command: /start-reload.sh # Only for development. Reloads Gunicorn when source changes.
     ports:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -14,11 +14,6 @@ class TestApp(unittest.TestCase):
     mock_placement_map = {'top-sites': [mock_response], 'text-promo': [mock_response_900]}
     mock_collection_placement_map = {'sponsored-collection': [mock_collection_response], 'spocs': [mock_response]}
 
-    def setUp(self):
-        sentry_patcher = patch('sentry_sdk.init')
-        sentry_patcher.start()
-        self.addCleanup(sentry_patcher.stop)
-
     @classmethod
     def create_client_no_geo_locs(cls) -> TestClient:
         from app.main import app


### PR DESCRIPTION
## Goal

Remove Sentry from Proxy Server as detailed in the ticket.


## Implementation Decisions

Note - the Pipfile dependency for `sentry-sdk` remains included, as it was too risky to take it out given the repository has not been updated/deployed in a while.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

## References

https://getpocket.atlassian.net/browse/BACK-1573