### PR TITLE
 Handle Brotlipy outdated hashes, option 1 (of many) - manually update SHAs

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -138,7 +138,16 @@
                 "sha256:c6cc0036b1304dd0073eec416cb2f6b9e37ac8296afd9e481cac3b1f07f9db25",
                 "sha256:d2c1c724c4ac375feb2110f1af98ecdc0e5a8ea79d068efb5891f621a5b235cb",
                 "sha256:dc6c5ee0df9732a44d08edab32f8a616b769cc5a4155a12d2d010d248eb3fb07",
-                "sha256:fd1d1c64214af5d90014d82cee5d8141b13d44c92ada7a0c0ec0679c6f15a471"
+                "sha256:fd1d1c64214af5d90014d82cee5d8141b13d44c92ada7a0c0ec0679c6f15a471",
+                "sha256:382971a641125323e90486244d6266ffb0e1f4dd920fbdcf508d2a19acc7c3b3",
+                "sha256:82f61506d001e626ec3a1ac8a69df11eb3555a4878599befcb672c8178befac8",
+                "sha256:7ff18e42f51ebc9d9d77a0db33f99ad95f01dd431e4491f0eca519b90e9415a9",
+                "sha256:8ef230ca9e168ce2b7dc173a48a0cc3d78bcdf0bd0ea7743472a317041a4768e",
+                "sha256:b7cf5bb69e767a59acc3da0d199d4b5d0c9fed7bef3ffa3efa80c6f39095686b",
+                "sha256:e5c549ae5928dda952463196180445c24d6fad2d73cb13bd118293aced31b771",
+                "sha256:79ab3bca8dd12c17e092273484f2ac48b906de2b4828dcdf6a7d520f99646ab3",
+                "sha256:ac1d66c9774ee62e762750e399a0c95e93b180e96179b645f28b162b55ae8adc",
+                "sha256:5664fe14f3a613431db622172bad923096a303d3adce55536f4409c8e2eafba4"
             ],
             "version": "==0.7.0"
         },

--- a/app/telemetry/handler.py
+++ b/app/telemetry/handler.py
@@ -24,6 +24,10 @@ def handle_message(event, context):
         for tile in telemetry["tiles"]:
             if "shim" in tile:
                 ping_adzerk(tile['shim'])
+    elif "metrics" in telemetry:
+        text_metrics = telemetry["metrics"].get("text", {})
+        if "pocket.spoc_shim" in text_metrics:
+            ping_adzerk(text_metrics["pocket.spoc_shim"])
 
 
 def ping_adzerk(shim):


### PR DESCRIPTION
## Goal

Currently, #74 is blocked by the CircleCI container environment wanting to install a copy of `brotlipy-0.7.0` Python package where its SHA from upstream doesn't match any of the SHAs in the Pipfile.lock.

One way to approach repairing this is to manually (e.g. outside of `pipenv`) update the hashes based on the pypi API. This is the command used to get all pypi hashes for `brotlipy` version 0.7.0 (note this is taken from fishshell, and easily altered to map to bash or zsh alternatives):

```
for sha in (curl https://pypi.org/pypi/brotlipy/0.7.0/json | jq -r .urls[].digests.sha256); echo "sha256:"$sha ; end
```
Those shas are then merged into the list in the `Pipfile.lock`, so all previously existing shas remain and the new ones alone are added in.

## Todos:
- [ ] If we decide to go this route, we probably should just add this new commit to the `relud-patch-1` branch then proceed with the original PR (#74) - or, rebase this branch to remove the `relud-patch-1` commits and merge this PR independently of #74.
- [x] ran CircleCI `tests_unit` job locally to confirm this repairs the issue;

## Implementation Decisions

Its not great to manually update the pipenv lockfile manually like this, but it is the most minimal way to update the hashes alone without touching anything else (which Pipenv would prefer to do by its design - see linked, alternative PR).

An alternative implementation to this is via this PR #76 .

## All Submissions:

- [ ] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
