### PR TITLE
fix(geolocation): [BACK-1696] Update GeoIP2 database

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ The following steps create a Docker development environment to run this service 
 2. In the project root run: `docker compose build`.
 3. Start a mock s3 service: `docker compose up s3`.
 4. Sign up for an account on the [MaxMind](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data?lang=en#accessing-geolite2-free-geolocation-data) website.
-5. Navigate to the "Download Files" page in your account, download the GeoLite2 City database and copy it to `pocket-geoip/GeoIP2-City.mmdb` on the mock s3 container.
+5. Navigate to the "Download Files" page in your account, download the GeoLite2 City database and copy it to `pocket-geoip/GeoLite2-City.mmdb` on the mock s3 container.
     1. If the database is stored on s3:
         ```
         images/s3/download.sh -b <s3 bucket>
         ```
     2. If it's stored on disk in a file called `GeoLite2-City.mmdb`:
         ```
-        aws --endpoint-url http://localhost:4569 s3 cp GeoLite2-City.mmdb s3://pocket-geoip/GeoIP2-City.mmdb
+        aws --endpoint-url http://localhost:4569 s3 cp GeoLite2-City.mmdb s3://pocket-geoip/GeoLite2-City.mmdb
         ```
-5. Verify that GeoIP2 is available at [localhost:4569/pocket-geoip/GeoIP2-City.mmdb](http://localhost:4569/pocket-geoip/GeoIP2-City.mmdb).
+5. Verify that GeoIP2 is available at [localhost:4569/pocket-geoip/GeoLite2-City.mmdb](http://localhost:4569/pocket-geoip/GeoLite2-City.mmdb).
 6. Create a `.env` file in the project root directory with the following content, replacing `<secret>` with the respective secret values:
     ```
     ADZERK_API_KEY=<secret>

--- a/app/conf/geolocation.py
+++ b/app/conf/geolocation.py
@@ -2,5 +2,5 @@ import os
 
 production = staging = development = test = {
     's3_bucket': os.environ.get('GEOIP_S3_BUCKET', 'GEOIP_S3_BUCKET'),
-    's3_key': 'GeoIP2-City.mmdb',
+    's3_key': 'GeoLite2-City.mmdb',
 }


### PR DESCRIPTION
## Goal

- We are moving from GeoIP2-City to GeoLite2-City database. Updated the name of the file the code is expecting to find in the S3 bucket (bucket has had new file uploaded already), updated README for local installation instructions.

## References

https://getpocket.atlassian.net/browse/BACK-1696