### PR TITLE
Fix connection pooling

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -2,6 +2,7 @@ from app import conf
 from app.adzerk.api import Api as AdZerk
 import app.adzerk.transform
 import logging
+from aiohttp import ClientSession
 
 
 class Client:
@@ -32,7 +33,7 @@ class Client:
         self.site = site
         self.placements = placements
 
-    async def get_spocs(self):
+    async def get_spocs(self, session: ClientSession):
         targeting = {"site": self.site}     # setting site here by default so it's picked up by API
 
         try:
@@ -55,7 +56,7 @@ class Client:
         targeting['placements'] = self.placements
 
         adzerk_api = AdZerk(**targeting)
-        decisions = await adzerk_api.get_decisions()
+        decisions = await adzerk_api.get_decisions(session)
 
         response = {
             'settings': app.conf.spocs['settings'],

--- a/app/provider/session_provider.py
+++ b/app/provider/session_provider.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+import aiohttp
+
+
+class SessionProvider:
+    """Singleton wrapper for an aiohttp ClientSession"""
+
+    __session: Optional[aiohttp.ClientSession] = None
+
+    @classmethod
+    def session(cls) -> aiohttp.ClientSession:
+        """Get the session singleton, creating it on first call"""
+
+        if cls.__session is None:
+            # 30 second timeout
+            timeout = aiohttp.ClientTimeout(total=30)
+
+            # Unlimited connection pool size
+            connector = aiohttp.TCPConnector(limit=None)
+
+            # Avoid persisting cookies across requests
+            cookie_jar = aiohttp.DummyCookieJar()
+
+            cls.__session = aiohttp.ClientSession(
+                connector=connector,
+                cookie_jar=cookie_jar,
+                timeout=timeout,
+            )
+
+        return cls.__session
+
+    @classmethod
+    async def shutdown(cls) -> None:
+        """Close the session and release resources"""
+
+        if cls.__session is None:
+            return
+
+        await cls.__session.close()
+        cls.__session = None

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -41,7 +41,8 @@ class TestApp(unittest.TestCase):
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     def test_app_pulse(self, mock_geo):
-        resp = self.create_client_no_geo_locs().get('/pulse')
+        with self.create_client_no_geo_locs() as client:
+            resp = client.get('/pulse')
         self.assertEqual(resp.json(), {"pulse" : "ok"})
 
 
@@ -51,7 +52,8 @@ class TestApp(unittest.TestCase):
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     def test_app_health(self, mock_geo):
-        resp = self.create_client_no_geo_locs().get('/health')
+        with self.create_client_no_geo_locs() as client:
+            resp = client.get('/health')
         self.assertEqual(resp.json(), {"health" : "ok"})
 
 
@@ -62,7 +64,8 @@ class TestApp(unittest.TestCase):
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
     async def test_app_spocs_production_valid(self, mock_geo, mock_adzerk):
-        resp = await self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body())
+        with self.create_client_no_geo_locs() as client:
+            resp = await client.post('/spocs', json=self.get_request_body())
         self.assertEqual(resp.status_code, 200)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
@@ -72,7 +75,8 @@ class TestApp(unittest.TestCase):
             'country': 'CA',
             'region': 'ON',
         }
-        resp = await self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(update=country_region))
+        with self.create_client_no_geo_locs() as client:
+            resp = await client.post('/spocs', json=self.get_request_body(update=country_region))
         self.assertEqual(resp.status_code, 200)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
@@ -82,7 +86,8 @@ class TestApp(unittest.TestCase):
         API version 1 returns the collection as an array for backwards compatibility.
         """
         request_body = self.get_request_body(placements=mock_collection_placements)
-        resp = await self.create_client_no_geo_locs().post('/spocs', json=request_body)
+        with self.create_client_no_geo_locs() as client:
+            resp = await client.post('/spocs', json=request_body)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['sponsored-collection'][0]['collection_title'], 'Best of the Web')
 
@@ -93,7 +98,8 @@ class TestApp(unittest.TestCase):
         API version 2 returns the collection as an object, with collection-level fields pulled up.
         """
         request_body = self.get_request_body(placements=mock_collection_placements, update={'version': '2'})
-        resp = await self.create_client_no_geo_locs().post('/spocs', json=request_body)
+        with self.create_client_no_geo_locs() as client:
+            resp = await client.post('/spocs', json=request_body)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['spocs'][0]['title'], 'title 1000')
 
@@ -107,19 +113,22 @@ class TestApp(unittest.TestCase):
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
     def test_app_spocs_production_invalid_no_version(self, mock_geo, mock_adzerk):
-        resp = self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(without='version'))
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=self.get_request_body(without='version'))
         self.assertEqual(resp.status_code, 400)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
     def test_app_spocs_production_invalid_no_pocket_id(self, mock_geo, mock_adzerk):
-        resp = self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(without='pocket_id'))
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=self.get_request_body(without='pocket_id'))
         self.assertEqual(resp.status_code, 400)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
     def test_app_spocs_production_invalid_no_consumer_key(self, mock_geo, mock_adzerk):
-        resp = self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(without='consumer_key'))
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=self.get_request_body(without='consumer_key'))
         self.assertEqual(resp.status_code, 400)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
@@ -127,7 +136,8 @@ class TestApp(unittest.TestCase):
     def test_app_spocs_production_invalid_pocket_id(self, mock_geo, mock_adzerk):
         data = self.get_request_body()
         data['pocket_id'] = 'invalid'
-        resp = self.create_client_no_geo_locs().post('/spocs', json=data)
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=data)
         self.assertEqual(resp.status_code, 400)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
@@ -135,13 +145,15 @@ class TestApp(unittest.TestCase):
     def test_app_spocs_production_unrecognized_field(self, mock_geo, mock_adzerk):
         data = self.get_request_body()
         data['invalid'] = 'something'
-        resp = self.create_client_no_geo_locs().post('/spocs', json=data)
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=data)
         self.assertEqual(resp.status_code, 400)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
     def test_app_spocs_production_invalid_content_type(self, mock_geo, mock_adzerk):
-        resp = self.create_client_no_geo_locs().post(
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post(
             '/spocs',
             headers={'Content-Type': 'text'},
             data=self.get_request_body()
@@ -158,33 +170,38 @@ class TestApp(unittest.TestCase):
         :param mock_adzerk:
         :return:
         """
-        resp = await self.create_client_no_geo_locs().post('/spocs?site=12345', json=self.get_request_body())
+        with self.create_client_no_geo_locs() as client:
+            resp = await client.post('/spocs?site=12345', json=self.get_request_body())
         self.assertEqual(resp.status_code, 200)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     def test_app_spocs_production_valid_placements(self, mock_geo):
-        resp = self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(placements=mock_placements))
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=self.get_request_body(placements=mock_placements))
         self.assertEqual(200, resp.status_code)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     def test_app_spocs_production_invalid_placement_name(self, mock_geo):
         bad_placements = deepcopy(mock_placements)
         bad_placements[0].pop('name')
-        resp = self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(placements=bad_placements))
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=self.get_request_body(placements=bad_placements))
         self.assertEqual(400, resp.status_code)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     def test_app_spocs_production_unknown_placement_field(self, mock_geo):
         bad_placements = deepcopy(mock_placements)
         bad_placements[0]['adTypess'] = ['test']
-        resp = self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(placements=bad_placements))
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=self.get_request_body(placements=bad_placements))
         self.assertEqual(400, resp.status_code)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_placement_map)
     async def test_app_spocs_production_valid_placements_call(self, mock_geo, mock_dec):
         bad_placements = deepcopy(mock_placements)
-        resp = await self.create_client_no_geo_locs().post('/spocs', json=self.get_request_body(placements=bad_placements))
+        with self.create_client_no_geo_locs() as client:
+            resp = await client.post('/spocs', json=self.get_request_body(placements=bad_placements))
         self.assertEqual(200, resp.status_code)
         result = resp.json()
         self.assertTrue('top-sites' in result)


### PR DESCRIPTION
## Goal

To decrease latency by reusing HTTPS connections to Kevel.

## Implementation Decisions

Currently we create a ClientSession for each request, which prevents connection reuse. This moves aiohttp ClientSession to app startup and passes the session down to the Kevel client so that we can reuse the connections. In local testing this reduces latency by ~200ms.

It also adds a dummy cookie jar so that we're not reusing cookies across requests.

It retains the TCPConnector with the unlimited connection pool size, but this could be reduced now that connections will actually stay around.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
