### PR TITLE
Limit ad_types and zone_ids to positive int32 values

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -101,11 +101,19 @@ components:
           description: https://dev.adzerk.com/docs/ad-sizes
           items:
             type: integer
+            format: int32
+            example: 1234
+            minimum: 1
+            maximum: 2147483647
         zone_ids:
           type: array
           description: https://dev.adzerk.com/docs/zones-overview
           items:
             type: integer
+            format: int32
+            example: 123456
+            minimum: 1
+            maximum: 2147483647
         count:
           type: integer
           example: 20


### PR DESCRIPTION
## Goal

Without this, schemathesis generates values too large to fit into int32, which breaks MARS.

Unfortunately, `format: int32` is not enough to achieve the desired result, as it's only considered a hint and not a hard constraint.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
