### PR TITLE
Add version: 2 to OpenAPI spec

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -65,12 +65,12 @@ components:
       properties:
         version:
           type: integer
-          description: API version. Currently `1` is the only version.
+          description: API version
           format: int32
           minimum: 1
-          maximum: 1
-          default: 1
-          example: 1
+          maximum: 2
+          default: 2
+          example: 2
         consumer_key:
           type: string
           description: Identifies that the request is coming from Firefox.


### PR DESCRIPTION
## Goal

Version 2 has been the default for /spocs for a long time, but the OpenAPI spec was never updated to reflect that.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
