### PR TITLE
Return decisions in API tests

### DIFF
--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -5,6 +5,7 @@ import schemathesis
 from aioresponses import aioresponses
 
 from tests.fixtures.mock_factory import get_mocked_geolocation_factory
+from tests.fixtures.mock_decision import mock_decision_2
 
 __FACTORY = get_mocked_geolocation_factory()
 with patch("app.geolocation.factory.Factory.get_instance", return_value=__FACTORY):
@@ -12,6 +13,15 @@ with patch("app.geolocation.factory.Factory.get_instance", return_value=__FACTOR
 
 schema = schemathesis.from_path("openapi/openapi.yml", app=app)
 
+
+MOCK_DECISIONS_RESPONSE = {
+    "user": {
+        "key": "{12345678-8901-2345-aaaa-bbbbbbcccccc}",
+    },
+    "decisions": {
+        "spocs": [mock_decision_2]
+    }
+}
 
 @responses.activate
 @schema.parametrize()
@@ -21,7 +31,7 @@ def test_api(case: schemathesis.Case) -> None:
 
     with aioresponses() as m:
         # Mock call to decisions API
-        m.post("https://e-10250.adzerk.net/api/v2", payload={"decisions": {}})
+        m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_RESPONSE)
 
         # Call Pocket Proxy and validate response
         response = case.call_asgi()


### PR DESCRIPTION
## Goal

This allows Schemathesis to actually test the response body. These tests were not failing because none of the response attributes are actually required.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
