### PR TITLE
Add tests for collections

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -24,12 +24,6 @@ paths:
                   version: 1
                   consumer_key: "40249-e88c401e1b1f2242d9e441c4"
                   pocket_id: "{12345678-8901-2345-aaaa-bbbbbbcccccc}"
-              version_two:
-                summary: Request from client that supports collections, FireFox version >= 75
-                values:
-                  version: 2
-                  consumer_key: "40249-e88c401e1b1f2242d9e441c4"
-                  pocket_id: "{12345678-8901-2345-aaaa-bbbbbbcccccc}"
       responses:
         '200':
           description: Responds with settings and a list of spocs.

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -17,6 +17,19 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SpocRequest'
+            examples:
+              version_one:
+                summary: Request from client that does not support collections, FireFox version <= 74
+                value:
+                  version: 1
+                  consumer_key: "40249-e88c401e1b1f2242d9e441c4"
+                  pocket_id: "{12345678-8901-2345-aaaa-bbbbbbcccccc}"
+              version_two:
+                summary: Request from client that supports collections, FireFox version >= 75
+                values:
+                  version: 2
+                  consumer_key: "40249-e88c401e1b1f2242d9e441c4"
+                  pocket_id: "{12345678-8901-2345-aaaa-bbbbbbcccccc}"
       responses:
         '200':
           description: Responds with settings and a list of spocs.
@@ -69,7 +82,6 @@ components:
           format: int32
           minimum: 1
           maximum: 2
-          default: 2
           example: 2
         consumer_key:
           type: string
@@ -228,6 +240,9 @@ components:
             sponsor:
               type: string
               example: NextAdvisor
+            context:
+              type: string
+              example: "Sponsored by NextAdvisor"
             items:
               type: array
               items:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -49,10 +49,19 @@ def test_delete_api(case: schemathesis.Case) -> None:
 def test_spocs_api(case: schemathesis.Case) -> None:
     with aioresponses() as m:
         # Mock call to decisions API
-        if case.body["version"] == 1:
-            m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_RESPONSE)
-        else:
-            m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_COLLECTION_RESPONSE)
+        m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_RESPONSE)
+
+        # Call Pocket Proxy and validate response
+        response = case.call_asgi()
+        case.validate_response(response)
+
+
+@responses.activate
+@schema.parametrize(endpoint="/spocs")
+def test_spocs_collection_api(case: schemathesis.Case) -> None:
+    with aioresponses() as m:
+        # Mock call to decisions API
+        m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_COLLECTION_RESPONSE)
 
         # Call Pocket Proxy and validate response
         response = case.call_asgi()

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -56,12 +56,18 @@ def test_spocs_api(case: schemathesis.Case) -> None:
         case.validate_response(response)
 
 
+def version_two(context, body):
+    return body.get("version") == 2
+
+
+# clients pass in version=2 if they support collections
 @responses.activate
+@schema.hooks.apply(version_two, name="filter_body")
 @schema.parametrize(endpoint="/spocs")
 def test_spocs_collection_api(case: schemathesis.Case) -> None:
     with aioresponses() as m:
         # Mock call to decisions API
-        m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_COLLECTION_RESPONSE)
+        m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_RESPONSE)
 
         # Call Pocket Proxy and validate response
         response = case.call_asgi()

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -5,7 +5,7 @@ import schemathesis
 from aioresponses import aioresponses
 
 from tests.fixtures.mock_factory import get_mocked_geolocation_factory
-from tests.fixtures.mock_decision import mock_decision_2
+from tests.fixtures.mock_decision import mock_decision_2, mock_collection_response
 
 __FACTORY = get_mocked_geolocation_factory()
 with patch("app.geolocation.factory.Factory.get_instance", return_value=__FACTORY):
@@ -23,15 +23,36 @@ MOCK_DECISIONS_RESPONSE = {
     }
 }
 
+MOCK_DECISIONS_COLLECTION_RESPONSE = {
+    "user": {
+        "key": "{12345678-8901-2345-aaaa-bbbbbbcccccc}",
+    },
+    "decisions": {
+        "spocs": [mock_collection_response]
+    }
+}
+
+
 @responses.activate
-@schema.parametrize()
-def test_api(case: schemathesis.Case) -> None:
+@schema.parametrize(endpoint="/user")
+def test_delete_api(case: schemathesis.Case) -> None:
     # Mock call to forget API
     responses.delete("https://e-10250.adzerk.net/udb/10250/")
 
+    # Call Pocket Proxy and validate response
+    response = case.call_asgi()
+    case.validate_response(response)
+
+
+@responses.activate
+@schema.parametrize(endpoint="/spocs")
+def test_spocs_api(case: schemathesis.Case) -> None:
     with aioresponses() as m:
         # Mock call to decisions API
-        m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_RESPONSE)
+        if case.body["version"] == 1:
+            m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_RESPONSE)
+        else:
+            m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_COLLECTION_RESPONSE)
 
         # Call Pocket Proxy and validate response
         response = case.call_asgi()

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -67,7 +67,7 @@ def version_two(context, body):
 def test_spocs_collection_api(case: schemathesis.Case) -> None:
     with aioresponses() as m:
         # Mock call to decisions API
-        m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_RESPONSE)
+        m.post("https://e-10250.adzerk.net/api/v2", payload=MOCK_DECISIONS_COLLECTION_RESPONSE)
 
         # Call Pocket Proxy and validate response
         response = case.call_asgi()


### PR DESCRIPTION
- adding test cases for version=1 spocs requests
- separating collections test, since v2 will do different things based on the kevel response, whereas v1 will return the same shape for both kinds of kevel responses

## Goal

This adds test cases for the spocs endpoint with collections returned from kevel. If the request version is 2 and the kevel response is a collection, then the shape of the response is adjusted slightly. [api spec definition](https://github.com/Pocket/proxy-server/pull/91/files#diff-f26912d4d2c7811bd456bf4f854b781a6a26384ea258dc55dfb592953cc4f9faR223-R227)

I removed the "default" value for version since that should be the server applied default if the value isn't supplied, but the field is required.

I also separated the tests by endpoint, so that it is more clear what kevel endpoints are invoked for each test case.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
