### PR TITLE
fix(nginx): docker image upstream dns

### DIFF
--- a/images/nginx/nginx.conf
+++ b/images/nginx/nginx.conf
@@ -26,7 +26,7 @@ http {
     #server unix:/tmp/gunicorn.sock fail_timeout=0;
 
     # for a TCP configuration
-    server app:8000 fail_timeout=0;
+    server 127.0.0.1:8000 fail_timeout=0;
   }
 
   server {


### PR DESCRIPTION
## Goal

On Jan 15th at 1amPT I received a page for the Proxy Server on it's CPU utilization. The service was trying to scale out in AWS and could not because it's tasks were dying with an essential container existing. Upon looking at the logs it seems that NGNIX was failing with an upstream not found.

<img width="866" alt="Screenshot 2024-01-15 at 1 33 24 AM" src="https://github.com/Pocket/proxy-server/assets/1010384/ea575982-b278-4fbf-ad6e-ad2165bd86ae">


I click-ops the service to retag an old NGINX image as latest for a temporary workaround.