### PR TITLE
AE-74 Added support for firefox-desktop Glean spoc ping

### DIFF
--- a/tests/unit/test_telemetry_handler.py
+++ b/tests/unit/test_telemetry_handler.py
@@ -9,16 +9,58 @@ from app.telemetry.handler import handle_message, ping_adzerk
 
 class TestTelemetryHandler(TestCase):
     @patch('app.telemetry.handler.ping_adzerk')
-    def test_handle_message(self, mock_ping_adzerk):
+    def test_handle_message_legacy_ping(self, mock_ping_adzerk):
         telemetry = {'tiles': [{'shim': '0,foo,bar'}, {'shim': '1,1,2'}, {'shim': '2,a,b'}]}
         data = base64.b64encode(gzip.compress(json.dumps(telemetry).encode('utf-8')))
+        attributes = {'document_namespace': 'activity-stream', 'document_type': 'impression-stats',
+                      'user_agent_version': 121}
 
-        handle_message(event={'data': data}, context={})
+        handle_message(event={'data': data, 'attributes': attributes}, context={})
         mock_ping_adzerk.assert_has_calls([
             call('0,foo,bar'),
             call('1,1,2'),
             call('2,a,b'),
         ])
+
+    @patch('app.telemetry.handler.ping_adzerk')
+    def test_handle_message_android_spoc_ping(self, mock_ping_adzerk):
+        telemetry = {'metrics': {'text': {'pocket.spoc_shim': '0,foo,bar'}}}
+        data = base64.b64encode(gzip.compress(json.dumps(telemetry).encode('utf-8')))
+        attributes = {'document_namespace': 'org-mozilla-firefox', 'document_type': 'spoc',
+                      'user_agent_version': 121}
+
+        handle_message(event={'data': data, 'attributes': attributes}, context={})
+        mock_ping_adzerk.assert_called_with('0,foo,bar')
+
+    @patch('app.telemetry.handler.ping_adzerk')
+    def test_handle_message_desktop_spoc_ping(self, mock_ping_adzerk):
+        telemetry = {'metrics': {'text': {'pocket.shim': '0,foo,bar'}}}
+        data = base64.b64encode(gzip.compress(json.dumps(telemetry).encode('utf-8')))
+        attributes = {'document_namespace': 'firefox-desktop', 'document_type': 'spoc',
+                      'user_agent_version': 122}
+
+        handle_message(event={'data': data, 'attributes': attributes}, context={})
+        mock_ping_adzerk.assert_called_with('0,foo,bar')
+
+    @patch('app.telemetry.handler.ping_adzerk')
+    def test_handle_unknown_namespace(self, mock_ping_adzerk):
+        telemetry = {'metrics': {'text': {'pocket.shim': '0,foo,bar'}}}
+        data = base64.b64encode(gzip.compress(json.dumps(telemetry).encode('utf-8')))
+        attributes = {'document_namespace': 'firefox-temp', 'document_type': 'spoc',
+                      'user_agent_version': 122}
+
+        handle_message(event={'data': data, 'attributes': attributes}, context={})
+        mock_ping_adzerk.assert_not_called()
+
+    @patch('app.telemetry.handler.ping_adzerk')
+    def test_handle_unknown_doctype(self, mock_ping_adzerk):
+        telemetry = {'metrics': {'text': {'pocket.shim': '0,foo,bar'}}}
+        data = base64.b64encode(gzip.compress(json.dumps(telemetry).encode('utf-8')))
+        attributes = {'document_namespace': 'firefox-desktop', 'document_type': 'temp',
+                      'user_agent_version': 122}
+
+        handle_message(event={'data': data, 'attributes': attributes}, context={})
+        mock_ping_adzerk.assert_not_called()
 
     @patch('urllib.request.urlopen')
     def test_ping_adzerk_r(self, mock_urlopen):

--- a/tests/unit/test_telemetry_handler.py
+++ b/tests/unit/test_telemetry_handler.py
@@ -43,6 +43,16 @@ class TestTelemetryHandler(TestCase):
         mock_ping_adzerk.assert_called_with('0,foo,bar')
 
     @patch('app.telemetry.handler.ping_adzerk')
+    def test_handle_message_desktop_spoc_ping_old_version(self, mock_ping_adzerk):
+        telemetry = {'metrics': {'text': {'pocket.shim': '0,foo,bar'}}}
+        data = base64.b64encode(gzip.compress(json.dumps(telemetry).encode('utf-8')))
+        attributes = {'document_namespace': 'firefox-desktop', 'document_type': 'spoc',
+                      'user_agent_version': 121}
+
+        handle_message(event={'data': data, 'attributes': attributes}, context={})
+        mock_ping_adzerk.assert_not_called()
+
+    @patch('app.telemetry.handler.ping_adzerk')
     def test_handle_unknown_namespace(self, mock_ping_adzerk):
         telemetry = {'metrics': {'text': {'pocket.shim': '0,foo,bar'}}}
         data = base64.b64encode(gzip.compress(json.dumps(telemetry).encode('utf-8')))


### PR DESCRIPTION
## Goal

Update the GCF to add processing for [Glean spoc ping](https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/pings/spoc).  This ping is needed due to the removal of activity stream and the legacy `impression-stats` ping starting in Firefox version 122.


## Todos:
- [ ] Outstanding todo
- [x] Completed todo

## Implementation Decisions
The previous version of the GCF relied on the structure of the JSON data to distinguish between desktop legacy `impression-stats` ping and Andoid Glean `spoc` ping.  This updated version relies on the attributes metadata included with the event.  Testing has been complete using production data to confirm the attribute dictionary does not require any decoding.

## All Submissions:

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
