### PR TITLE
filter client disconnect errors from sentry reporting

### DIFF
--- a/app/provider/sentry_provider.py
+++ b/app/provider/sentry_provider.py
@@ -3,6 +3,22 @@ import logging
 import sentry_sdk
 
 from app import conf
+from starlette.requests import ClientDisconnect
+
+
+SENTRY_IGNORE_ERRORS = (
+    ClientDisconnect
+)
+
+
+def before_send(event, hint):
+    if hint and "exc_info" in hint:
+        exc_type, exc_value, tb = hint["exc_info"]
+        if isinstance(exc_value, SENTRY_IGNORE_ERRORS):
+            return None
+
+    return event
+
 
 def sentry_init():
     dsn = conf.sentry['dsn']
@@ -15,5 +31,6 @@ def sentry_init():
             traces_sample_rate=traces_sample_rate,
             profiles_sample_rate=profiles_sample_rate,
             environment=conf.env,
+            before_send=before_send
     )
 


### PR DESCRIPTION
## Goal

ClientDisconnect errors are getting sent to sentry in gcp (AWS deploy was not hooked up to sentry), and these errors can get raised when trying to parse a request json body.

The stacktrace is easy to see in the related sentry issue
https://mozilla.sentry.io/issues/4935558485/?project=4506543461302272

This mimics what bedrock is already doing for errors they have seen. https://github.com/bkochendorfer/bedrock/blob/b98c15e3e17a4d2d3e05afb75d6402d2f558a658/bedrock/settings/base.py#L1151

### Testing

I haven't done any testing, not really sure what the best way would be to do so.

## Implementation Decisions

I think ideally these errors would be handled nicely by the application handler rather than raised as exceptions. I wasn't sure what other implications would be by adjusting this catch block
https://github.com/Pocket/proxy-server/blob/main/app/main.py#L144-L147

## All Submissions:

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
