### PR TITLE
raise invalidParam exception to return a 400 when an invalid version is passed in

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -96,6 +96,13 @@ async def call(client_ip, req_params, required_params, optional_params=None):
         __validate_placements(other_params['placements'])
     params.update(other_params)
 
+    # validate that the version param is a valid int
+    if 'version' in params:
+        try:
+            int(params['version'])
+        except ValueError:
+            raise InvalidParam('Invalid version')
+
     client = Client(ip=client_ip, geolocation_provider=provider, **params)
     session = SessionProvider.session()
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -152,6 +152,17 @@ class TestApp(unittest.TestCase):
             resp = client.post('/spocs', json=data)
         self.assertEqual(resp.status_code, 400)
 
+
+    @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
+    @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
+    def test_app_spocs_production_invalid_version_value(self, mock_geo, mock_adzerk):
+        data = self.get_request_body()
+        data['version'] = '2'' /**/ should sanitize input'
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=data)
+        self.assertEqual(resp.status_code, 400)
+
+
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
     def test_app_spocs_production_invalid_content_type(self, mock_geo, mock_adzerk):


### PR DESCRIPTION
## Goal

Now that we have visibility into errors in sentry, these have already started showing up. the 'version' param is assumed to be an integer but there is not any validation.
https://mozilla.sentry.io/issues/4935716151/?project=4506543461302272

## Implementation Decisions

try parsing the version param as an int before instantiating the client so that we can raise a parameter exception for a bad parameter.

### Testing

`pipenv run pytest tests/unit/`

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
