### PR TITLE
more parameter validations

### DIFF
--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -211,6 +211,20 @@ class TestApp(unittest.TestCase):
         self.assertEqual(400, resp.status_code)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
+    def test_app_spocs_production_invalid_json(self, mock_geo):
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json='${${[]}}')
+        self.assertEqual(400, resp.status_code)
+
+    @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
+    def test_app_spocs_production_invalid_placement(self, mock_geo):
+        bad_placements = deepcopy(mock_placements)
+        bad_placements[0] = 'map[ad_types:[3120] name:foo zone_ids:[280143]]'
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=self.get_request_body(placements=bad_placements))
+        self.assertEqual(400, resp.status_code)
+
+    @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_placement_map)
     def test_app_spocs_production_valid_placements_call(self, mock_geo, mock_dec):
         bad_placements = deepcopy(mock_placements)


### PR DESCRIPTION
## Goal

Handle more cases of bad input.
* unicode decode errors for bad json body https://mozilla.sentry.io/issues/4937115586/?project=4506543461302272 (I didn't add a test for this one, I couldn't figure out what bytes are causing it. So there is a new except handler for this error with no corresponding test
* invalid json body that passes parsing, but isn't a dict https://mozilla.sentry.io/issues/4937372907/?project=4506543461302272
* invalid placements https://mozilla.sentry.io/issues/4937867511/?project=4506543461302272

## Implementation Decisions

I tried going down the path of having fastAPI validate and parse request bodies, but ran into difficulties with the tests since we parse the ip address from the request as well.
https://fastapi.tiangolo.com/tutorial/body/

Since that was turning into a rabbit hole, I switched to do these smaller exception handlings for the errors we're seeing.

## All Submissions:

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
