### PR TITLE
add supported query params for spocs endpoint

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -11,6 +11,25 @@ paths:
     post:
       summary: Get sponsored content
       description: Get a list of spocs based on region and pocket_id from AdZerk. The IP address is used to deduce a rough geographic region, for example "Texas" in the U.S. or "England" in the U.K. The IP is not stored or shared with AdZerk to preserve privacy.
+      parameters:
+        - in: query
+          name: site
+          schema:
+            type: integer
+          required: false
+          description: override siteId in ad decision requests
+        - in: query
+          name: region
+          schema:
+            type: integer
+          required: false
+          description: override region in keywords of ad decision requests for testing
+        - in: query
+          name: country
+          schema:
+            type: integer
+          required: false
+          description: override country in keywords of ad decision requests for testing
       requestBody:
         required: true
         content:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -21,13 +21,13 @@ paths:
         - in: query
           name: region
           schema:
-            type: integer
+            type: string
           required: false
           description: override region in keywords of ad decision requests for testing
         - in: query
           name: country
           schema:
-            type: integer
+            type: string
           required: false
           description: override country in keywords of ad decision requests for testing
       requestBody:
@@ -137,6 +137,15 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Placement"
+        site:
+          type: integer
+          description: override siteId in ad decision requests
+        country:
+          type: string
+          description: override country in keywords of ad decision requests for testing
+        region:
+          type: string
+          description: override region in keywords of ad decision requests for testing
 
     Placement:
       type: object

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -183,7 +183,7 @@ class TestApp(unittest.TestCase):
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
-    def test_app_spocs_staging_production_valid(self, mock_geo, mock_adzerk):
+    def test_app_spocs_staging_production_valid_query_param(self, mock_geo, mock_adzerk):
         """
         This test would be more useful if we checked that we got different responses based on the site.
         But currently not sure how to return a mocked response based on site, or even to test
@@ -193,6 +193,16 @@ class TestApp(unittest.TestCase):
         """
         with self.create_client_no_geo_locs() as client:
             resp = client.post('/spocs?site=12345', json=self.get_request_body())
+        self.assertEqual(resp.status_code, 200)
+
+    @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
+    @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
+    def test_app_spocs_staging_production_valid(self, mock_geo, mock_adzerk):
+        site = {
+            'site': '12345'
+        }
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs', json=self.get_request_body(update=site))
         self.assertEqual(resp.status_code, 200)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -83,6 +83,13 @@ class TestApp(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
     @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
+    @patch('app.adzerk.api.Api.get_decisions', return_value=mock_response_map)
+    def test_app_spocs_production_valid_with_country_region_query_param(self, mock_geo, mock_adzerk):
+        with self.create_client_no_geo_locs() as client:
+            resp = client.post('/spocs?country=CA&region=ON', json=self.get_request_body())
+        self.assertEqual(resp.status_code, 200)
+
+    @patch('app.provider.geo_provider.GeolocationProvider.__init__', return_value=None)
     @patch('app.adzerk.api.Api.get_decisions', return_value=mock_collection_placement_map)
     def test_app_spocs_collection_v1(self, mock_geo, mock_adzerk):
         """


### PR DESCRIPTION
## Goal

the proxy supports query parameters for the spocs endpoint but they are not specified in the api spec. https://swagger.io/docs/specification/describing-parameters/ helped me figure out how to put these in the spec

https://github.com/Pocket/proxy-server/blob/main/app/main.py#L160-L162
* site, country, and region are the supported params

site is added as a param here, configured via `browser.newtabpage.activity-stream.discoverystream.spocSiteId`
https://searchfox.org/mozilla-central/source/browser/components/newtab/lib/DiscoveryStreamFeed.sys.mjs#627-631

country and region are configured via `browser.newtabpage.activity-stream.discoverystream.spocs-endpoint-query` which allows any query param to be appended to the spocs request
https://searchfox.org/mozilla-central/source/browser/components/newtab/lib/DiscoveryStreamFeed.sys.mjs#523-541
https://searchfox.org/mozilla-central/source/browser/components/newtab/lib/DiscoveryStreamFeed.sys.mjs#687-688

this doesn't change any functionality


## All Submissions:

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
