### PR TITLE
handle ClientDisconnect errors raicsed when reading post body, don't log geo warnings on ip not in db

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -41,7 +41,6 @@ class Client:
             targeting['country'] = self.geolocation.get_country(geo)
             targeting['region'] = self.geolocation.get_region(geo)
         except Exception as e:
-            # logging.warning("Could not target based on geolocation. {0}".format(str(e)))
             pass
 
         if self.country:

--- a/app/client.py
+++ b/app/client.py
@@ -41,7 +41,8 @@ class Client:
             targeting['country'] = self.geolocation.get_country(geo)
             targeting['region'] = self.geolocation.get_region(geo)
         except Exception as e:
-            logging.warning("Could not target based on geolocation. {0}".format(str(e)))
+            # logging.warning("Could not target based on geolocation. {0}".format(str(e)))
+            pass
 
         if self.country:
             targeting['country'] = self.country

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,9 @@ from typing import Dict
 
 import uvicorn
 from starlette.responses import JSONResponse
-from fastapi import FastAPI, Request
+from starlette.requests import ClientDisconnect
+from starlette.status import HTTP_204_NO_CONTENT
+from fastapi import FastAPI, Request, Response
 
 from app.adzerk.api import Api as AdZerk
 from app.client import Client
@@ -43,14 +45,17 @@ provider = GeolocationProvider()
 
 @app.post('/spocs')
 async def get_spocs(request: Request):
-    required_params = set(['version', 'consumer_key', 'pocket_id'])
-    optional_params = set(['site', 'placements', 'country', 'region'])
-    req_params = await __get_request_params(request)
-    if request.client is not None:
-        client_host = request.client.host
-    else:
-        client_host = ""
-    return await call(client_host, req_params, required_params, optional_params=optional_params)
+    try:
+        required_params = set(['version', 'consumer_key', 'pocket_id'])
+        optional_params = set(['site', 'placements', 'country', 'region'])
+        req_params = await __get_request_params(request)
+        if request.client is not None:
+            client_host = request.client.host
+        else:
+            client_host = ""
+        return await call(client_host, req_params, required_params, optional_params=optional_params)
+    except ClientDisconnect:
+        return Response(status_code=HTTP_204_NO_CONTENT)
 
 
 @app.delete('/user')

--- a/app/main.py
+++ b/app/main.py
@@ -55,7 +55,7 @@ async def get_spocs(request: Request):
             client_host = ""
         return await call(client_host, req_params, required_params, optional_params=optional_params)
     except ClientDisconnect:
-        return Response(status_code=HTTP_204_NO_CONTENT)
+        pass
 
 
 @app.delete('/user')


### PR DESCRIPTION
## Goal

1. I believe that ClientDisconnect exceptions getting raised from reading the post body and the client disconnecting are showing up as 500s on our graphs. We should handle disconnects gracefully since the client is no longer waiting for a response. [starlette requests.py](https://github.com/encode/starlette/blob/master/starlette/requests.py#L221-L253)
3. Looking at our logs in google is difficult because of the volume of noise. 40%+ of the logs are coming from ips not existing in our geo db.

[cloud logs](https://console.cloud.google.com/logs/query;query=resource.labels.container_name%3D%22pocket-proxy%22%0A--Hide%20similar%20entries%0A--%2528textPayload%3D~%22WARNING:root:Could%20not%20target%20based%20on%20geolocation%5C.%20The%20address%20%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20is%20not%20in%20the%20database%5C.%22%2529%0A--End%20of%20hide%20similar%20entries;storageScope=storage,projects%2Fmoz-fx-ads-prod%2Flocations%2Fglobal%2Fbuckets%2Fgke-ads-prod-log-bucket%2Fviews%2F_AllLogs;cursorTimestamp=2024-02-08T17:35:32.829691930Z;duration=PT1H?project=moz-fx-ads-prod)


## Implementation Decisions

I tried reading FastAPI docs on what is best to do with ClientDisconnect exceptions to handle them and couldn't find any concrete direction. Mainly they would comment that you could detect the disconnect with `await request.is_disconnected()` [starlette docs](https://www.starlette.io/requests/) Since the client isn't waiting for a response, I wasn't sure which response makes sense for the handler to return.

The ips not existing in the db can be filtered in google logs UI, but it also seemed like something that isn't really actionable so it felt like extra noise.

## Testing
`pipenv run pytest tests/api`
`pipenv run pytest tests/unit`

## All Submissions:

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
